### PR TITLE
Use YT no cookie embed url

### DIFF
--- a/components/features/features-content.tsx
+++ b/components/features/features-content.tsx
@@ -113,7 +113,7 @@ export const hiddenContent: FeatureProps[] = [
     iframeList: [
       {
         source:
-          'https://www.youtube.com/embed/MErBf3sTn-A?modestbranding=1&rel=0',
+          '"https://www.youtube-nocookie.com/embed/MErBf3sTn-A?modestbranding=1&rel=0',
         style: {
           height: '100%',
           marginLeft: 0,

--- a/components/why-kedro/why-kedro.tsx
+++ b/components/why-kedro/why-kedro.tsx
@@ -2,8 +2,6 @@ import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { tabData } from './why-kedro-data';
 
-import Media from '../media';
-
 import style from './why-kedro.module.scss';
 
 export default function WhyKedro() {
@@ -58,7 +56,7 @@ export default function WhyKedro() {
             frameBorder="0"
             height="100%"
             loading="lazy"
-            src="https://www.youtube.com/embed/yEQqf3XUvzk?modestbranding=1&rel=0"
+            src="https://www.youtube-nocookie.com/embed/yEQqf3XUvzk?modestbranding=1&rel=0"
             title="YouTube video player"
             width="100%"
           ></iframe>


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

I was seeing a lot of `SameSite` cookie issues in Chrome's dev tools, and I'm hoping this will fix that.


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
