### PR TITLE
Fix the section navigation and sticky header on mobile-mode. 

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,17 +11,23 @@ import ReadyToStart from '../components/ready-to-start';
 import Testimonials from '../components/testimonials';
 import WhyKedro from '../components/why-kedro';
 import Footer from '../components/footer';
+import { Size, useWindowSize } from '../utils/hooks/useWindowSize';
+
+const MOBILE_BREAKPOINT = 819;
 
 const Home = () => {
   const footerRef = useRef();
   const onScreen = useOnScreen(footerRef);
+
+  const size: Size = useWindowSize();
+  const isMobile = size.width > MOBILE_BREAKPOINT ? false : true;
 
   return (
     <>
       <Head>
         <title>Kedro</title>
       </Head>
-      {!onScreen && <Header />}
+      {(!onScreen || isMobile) && <Header />}
       <Hero />
       <WhyKedro />
       <Features />

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -31,6 +31,6 @@ a {
 :target:before {
   content: '';
   display: block;
-  height: $header_height + 30px; /* fixed header height*/
-  margin: -($header_height + 30px) 0 0; /* negative fixed header height */
+  height: $header_height; /* fixed header height*/
+  margin: -($header_height - 50px) 0 0; /* negative fixed header height */
 }


### PR DESCRIPTION
## Description

Previously, when you navigated to any section in the mobile-mode, the title would be cut off a bit. This PR fixes that. 

While fixing the section navigation, I also realised that when you navigate to Get Started section -- the header is hidden because you almost reach the footer section and the footer is also not visible in the mobile mode. 

Hence, for mobile mode, decided to not hide the header. 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behavior changed? What testing strategies have you used? Have you QAed your final work with the design team? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
