### PR TITLE
Add the NHS to the used and loved by section

### DIFF
--- a/components/companies-using-kedro/companies-using-kedro-content.tsx
+++ b/components/companies-using-kedro/companies-using-kedro-content.tsx
@@ -33,7 +33,7 @@ export const companies = [
     link: 'https://medium.com/indiciumtech/how-to-build-models-as-products-using-mlops-part-2-machine-learning-pipelines-with-kedro-10337c48de92',
   },
   {
-    name: 'NHS',
+    name: 'NHS AI Lab',
     link: 'https://nhsx.github.io/skunkworks/synthetic-data-pipeline',
   },
   {

--- a/components/companies-using-kedro/companies-using-kedro-content.tsx
+++ b/components/companies-using-kedro/companies-using-kedro-content.tsx
@@ -1,0 +1,64 @@
+export const companies = [
+  {
+    name: 'Telkomsel',
+    link: 'https://medium.com/life-at-telkomsel/how-we-build-a-production-grade-data-pipeline-7004e56c8c98',
+  },
+  {
+    name: 'Beamery',
+    link: 'https://medium.com/hacking-talent/production-code-for-data-science-and-our-experience-with-kedro-60bb69934d1f',
+  },
+  { name: 'NASA', link: 'https://github.com/nasa/ML-airport-configuration' },
+  {
+    name: 'Belfius',
+    link: 'https://www.linkedin.com/posts/vangansen_mlops-machinelearning-kedro-activity-6772379995953238016-JUmo/',
+  },
+  {
+    name: 'Sber',
+    link: 'https://www.linkedin.com/posts/seleznev-artem_welcome-to-kedros-documentation-kedro-activity-6767523561109385216-woTt/?ref=morioh.com&utm_source=morioh.com',
+  },
+  {
+    name: 'Augment Partners',
+    link: 'https://www.linkedin.com/posts/augment-partners_kedro-cheat-sheet-by-augment-activity-6858927624631283712-Ivqk/?ref=morioh.com&utm_source=morioh.com',
+  },
+  {
+    name: 'McKinsey & Company',
+    link: 'https://www.mckinsey.com/alumni/news-and-insights/global-news/firm-news/kedro-from-proprietary-to-open-source',
+  },
+  {
+    name: 'GetInData',
+    link: 'https://getindata.com/blog/running-machine-learning-pipelines-kedro-kubeflow-airflow',
+  },
+  {
+    name: 'Indicium',
+    link: 'https://medium.com/indiciumtech/how-to-build-models-as-products-using-mlops-part-2-machine-learning-pipelines-with-kedro-10337c48de92',
+  },
+  {
+    name: 'NHS',
+    link: 'https://nhsx.github.io/skunkworks/synthetic-data-pipeline',
+  },
+  {
+    name: 'GMO',
+    link: 'https://recruit.gmo.jp/engineer/jisedai/engineer/jisedai/engineer/jisedai/engineer/jisedai/engineer/jisedai/blog/kedro_and_mlflow_tracking/',
+  },
+  {
+    name: 'QuantumBlack',
+    link: 'https://medium.com/quantumblack/introducing-kedro-the-open-source-library-for-production-ready-machine-learning-code-d1c6d26ce2cf',
+  },
+  { name: 'XP', link: 'https://youtu.be/wgnGOVNkXqU?t=2210' },
+  {
+    name: 'AI Singapore',
+    link: 'https://makerspace.aisingapore.org/2020/08/leveraging-kedro-in-100e/',
+  },
+  {
+    name: 'Helvetas',
+    link: 'https://www.linkedin.com/posts/lionel-trebuchon_mlflow-kedro-ml-ugcPost-6747074322164154368-umKw',
+  },
+  {
+    name: 'Leapfrog',
+    link: 'https://www.lftechnology.com/blog/ai-pipeline-kedro/',
+  },
+  {
+    name: 'Naranja',
+    link: 'https://medium.com/quantumblack/odelsa-uses-kedro-for-social-good-3c7e7fc20306',
+  },
+];

--- a/components/companies-using-kedro/companies-using-kedro.module.scss
+++ b/components/companies-using-kedro/companies-using-kedro.module.scss
@@ -80,6 +80,7 @@
     $color-dark
   );
   height: 30rem;
+  pointer-events: none;
   position: relative;
 
   @include breakpoint(small) {
@@ -105,6 +106,11 @@
   }
 }
 
-.active {
+.active > a {
   color: $color-accent;
+  transition: opacity $transition-time ease;
+
+  &:hover {
+    opacity: 0.85;
+  }
 }

--- a/components/companies-using-kedro/companies-using-kedro.tsx
+++ b/components/companies-using-kedro/companies-using-kedro.tsx
@@ -10,6 +10,7 @@ export const companies = [
   'McKinsey & Company',
   'GetInData',
   'Indicium',
+  'NHS',
   'GMO',
   'QuantumBlack',
   'XP',

--- a/components/companies-using-kedro/companies-using-kedro.tsx
+++ b/components/companies-using-kedro/companies-using-kedro.tsx
@@ -1,24 +1,7 @@
 import React, { useEffect } from 'react';
-import style from './companies-using-kedro.module.scss';
+import { companies } from './companies-using-kedro-content';
 
-export const companies = [
-  'Telkomsel',
-  'NASA',
-  'Belfius',
-  'Sber',
-  'Augment Partners',
-  'McKinsey & Company',
-  'GetInData',
-  'Indicium',
-  'NHS',
-  'GMO',
-  'QuantumBlack',
-  'XP',
-  'AI Singapore',
-  'Helvetas',
-  'Leapfrog',
-  'Naranja',
-];
+import style from './companies-using-kedro.module.scss';
 
 export default function CompaniesUsingKedro() {
   useEffect(() => {
@@ -69,15 +52,53 @@ export default function CompaniesUsingKedro() {
         <div className={style.right}>
           <div className={style.animation}>
             <ul>
-              <li>Leapfrog</li>
-              <li>Naranja</li>
+              <li>
+                <a
+                  href="https://www.lftechnology.com/blog/ai-pipeline-kedro/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Leapfrog
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://medium.com/quantumblack/odelsa-uses-kedro-for-social-good-3c7e7fc20306"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Naranja
+                </a>
+              </li>
               {companies.map((company, i) => (
                 <li key={i} className={i == 0 ? style.active : ''}>
-                  {company}
+                  <a
+                    href={company.link}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    {company.name}{' '}
+                  </a>
                 </li>
               ))}
-              <li>Beamery</li>
-              <li>Telkomsel</li>
+              <li>
+                <a
+                  href="https://medium.com/hacking-talent/production-code-for-data-science-and-our-experience-with-kedro-60bb69934d1f"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Beamery
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://medium.com/life-at-telkomsel/how-we-build-a-production-grade-data-pipeline-7004e56c8c98"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Telkomsel
+                </a>
+              </li>
             </ul>
           </div>
           <div className={style.animationMask}></div>


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

@datajoely found out that the NHS [uses Kedro](https://nhsx.github.io/skunkworks/synthetic-data-pipeline)! This adds them to the **Used and loved by** section of the website.

## QA notes

![image](https://user-images.githubusercontent.com/16869061/176188953-9bbcc6cd-f5bc-4c36-8382-a394e956d3e8.png)

Question from me: is it simply **NHS** or **The NHS**?


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
