### PR TITLE
Update Twitter share card meta tags

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -12,7 +12,10 @@ export default function Document() {
 
         <meta property="og:title" content="Kedro" />
         <meta property="og:type" content="website" />
-        <meta property="og:image" content="/images/kedro-social-image.png" />
+        <meta
+          content="https://kedro.org/images/kedro-social-image.png"
+          property="og:image"
+        />
         <meta property="og:url" content="https://kedro.org/" />
         <meta
           content="A Python framework for creating reproducible, maintainable and modular data science code."
@@ -25,7 +28,7 @@ export default function Document() {
           name="twitter:image:alt"
         />
         <meta
-          content="/images/kedro-social-image.png"
+          content="https://kedro.org/images/kedro-social-image.png"
           name="twitter:image"
         ></meta>
         <meta name="twitter:title" content="Kedro"></meta>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -14,16 +14,25 @@ export default function Document() {
         <meta property="og:type" content="website" />
         <meta property="og:image" content="/images/kedro-social-image.png" />
         <meta property="og:url" content="https://kedro.org/" />
-        <meta name="twitter:card" content="summary_large_image" />
         <meta
-          property="og:description"
           content="A Python framework for creating reproducible, maintainable and modular data science code."
+          property="og:description"
         />
         <meta property="og:site_name" content="Kedro" />
+        <meta name="twitter:card" content="summary_large_image" />
         <meta
-          name="twitter:image:alt"
           content="A Python framework for creating reproducible, maintainable and modular data science code."
+          name="twitter:image:alt"
         />
+        <meta
+          content="/images/kedro-social-image.png"
+          name="twitter:image"
+        ></meta>
+        <meta name="twitter:title" content="Kedro"></meta>
+        <meta
+          name="twitter:description"
+          content="A Python framework for creating reproducible, maintainable and modular data science code."
+        ></meta>
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

Fixes #55 

## Development notes

I've added the relevant Twitter meta tags.

## QA notes

I think we can use [this app](https://tweetpik.com/twitter-card-validator) to check if the card will appear correctly. It looks like it is now: 

<img width="509" alt="image" src="https://user-images.githubusercontent.com/16869061/185943773-1c2e8d31-eae4-4116-9246-6d88b6637ad7.png">

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
