### PR TITLE
Update Get Started link destination

### DIFF
--- a/components/footer/footer.module.scss
+++ b/components/footer/footer.module.scss
@@ -89,6 +89,11 @@
   display: flex;
   font-size: 0.875rem;
   margin: 1rem;
+  transition: color $transition-time ease;
+
+  &:hover {
+    color: $color-accent;
+  }
 }
 
 .linux {

--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -22,7 +22,12 @@ export default function Footer() {
           <a href="#features" className={style.link}>
             Features
           </a>
-          <a href="#" className={style.link}>
+          <a
+            className={style.link}
+            href="https://kedro.readthedocs.io/en/stable/02_get_started/01_prerequisites.html"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             Get Started
           </a>
           <a

--- a/components/header/header.module.scss
+++ b/components/header/header.module.scss
@@ -97,6 +97,11 @@
   color: $color-font;
   display: flex;
   margin: 1rem;
+  transition: color $transition-time ease;
+
+  &:hover {
+    color: $color-accent;
+  }
 }
 
 .burger {

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -28,7 +28,12 @@ export default function Header() {
           <a href="#features" className={style.link}>
             Features
           </a>
-          <a href="#get-started" className={style.link}>
+          <a
+            className={style.link}
+            href="https://kedro.readthedocs.io/en/stable/02_get_started/01_prerequisites.html"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             Get Started
           </a>
           <a
@@ -62,9 +67,9 @@ export default function Header() {
             >
               <Image
                 alt="GithubLogo"
+                height={30}
                 src="/images/github.svg"
                 width={30}
-                height={30}
               />
               <span className={style.iconText}> Github</span>
             </a>


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

The Get Started link in the header and footer take the user to a module on the page when they should really take you to the Kedro docs website. This PR will make that happen, so the user will get there in one click instead of a confusing two.

Note a decent amount of people are clicking this. Just yesterday there were 11 clicks of this link:

![image](https://user-images.githubusercontent.com/16869061/186510758-bb1df92d-c35f-42db-99b8-5742c3affa60.png)

That was 11 people taken to another place on the page. With this, they'll all be taken to the Kedro docs 💥 

## Development notes

I've also updated the text color of links on hover in the header and footer to match that of the other text links on the page.

## QA notes

Take a look at the deployed URL and see that the link takes you to the Kedro docs website.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
