### PR TITLE
Feature/blog author page

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -213,7 +213,7 @@ export async function getAllAuthors() {
 export async function getSingleAuthor(author) {
   const entries = await fetchGraphQL(
     `query {
-      authorCollection(where: {urlDisplayName: "${author}"}, limit: 20, order: sys_firstPublishedAt_DESC) {
+      authorCollection(where: {urlDisplayName: "${author}"}, limit: 20) {
         items {
           name
           bio

--- a/lib/api.js
+++ b/lib/api.js
@@ -226,6 +226,8 @@ export async function getSingleAuthor(author) {
               items {
                 slug
                 sys {
+                  firstPublishedAt
+                  id
                   publishedAt
                 }
                 title

--- a/lib/api.js
+++ b/lib/api.js
@@ -213,20 +213,28 @@ export async function getAllAuthors() {
 export async function getSingleAuthor(author) {
   const entries = await fetchGraphQL(
     `query {
-      authorCollection(where: {urlDisplayName: "${author}"}) {
+      authorCollection(where: {urlDisplayName: "${author}"}, limit: 20) {
         items {
           name
+          bio
           picture {
             url
           }
+          jobTitle
           linkedFrom {
             postCollection {
               items {
                 slug
-                title
                 sys {
                   publishedAt
                 }
+                title
+                category
+                coverImage {
+                  url
+                }
+                description
+                readingTime
               }
             }
           }

--- a/lib/api.js
+++ b/lib/api.js
@@ -213,7 +213,7 @@ export async function getAllAuthors() {
 export async function getSingleAuthor(author) {
   const entries = await fetchGraphQL(
     `query {
-      authorCollection(where: {urlDisplayName: "${author}"}, limit: 20) {
+      authorCollection(where: {urlDisplayName: "${author}"}, limit: 20, order: sys_firstPublishedAt_DESC) {
         items {
           name
           bio

--- a/modules/blog/posts-list/posts-list.tsx
+++ b/modules/blog/posts-list/posts-list.tsx
@@ -69,9 +69,11 @@ const PostsList = ({ post }: PostsList) => {
       </Link>
       <p className={style.description}>{post.description}</p>
       <div className={style.authorWrapper}>
-        <Link href={`/blog/author/${post.author.urlDisplayName}`}>
-          <a className={style.author}>{post.author.name}</a>
-        </Link>
+        {post.author && (
+          <Link href={`/blog/author/${post.author.urlDisplayName}`}>
+            <a className={style.author}>{post.author.name}</a>
+          </Link>
+        )}
         <p className={style.date}>
           {dateFormatting(post.sys.firstPublishedAt)}
         </p>

--- a/pages/blog/author/[author].tsx
+++ b/pages/blog/author/[author].tsx
@@ -86,11 +86,19 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
               </section>
 
               <Link href="/blog" passHref>
-                <div className={style.buttonWrapper}>
-                  <button className={style.backButton}>
-                    Back to Blog home
-                  </button>
-                </div>
+                <a>
+                  <div className={style.buttonWrapper}>
+                    <button className={style.backButton}>
+                      <Image
+                        alt="Back arrow"
+                        height={22}
+                        src="/images/back-arrow.svg"
+                        width={22}
+                      />
+                      Back to Blog home
+                    </button>
+                  </div>
+                </a>
               </Link>
             </div>
           </article>

--- a/pages/blog/author/[author].tsx
+++ b/pages/blog/author/[author].tsx
@@ -35,13 +35,6 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
     return <ErrorPage statusCode={404} />;
   }
 
-  const sortedDatePosts = authorsPosts.sort((a, b) => {
-    return (
-      new Date(b.sys.firstPublishedAt).valueOf() -
-      new Date(a.sys.firstPublishedAt).valueOf()
-    );
-  });
-
   return (
     <>
       {router.isFallback ? (
@@ -82,7 +75,7 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
                   Posts by <strong>{authorInfo.name}</strong>
                 </p>
                 <div>
-                  {sortedDatePosts.map((post) => {
+                  {authorsPosts.map((post) => {
                     return (
                       <div key={post.slug}>
                         <PostsList key={post.sys.id} post={post} />

--- a/pages/blog/author/[author].tsx
+++ b/pages/blog/author/[author].tsx
@@ -35,6 +35,13 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
     return <ErrorPage statusCode={404} />;
   }
 
+  const sortedDatePosts = authorsPosts.sort((a, b) => {
+    return (
+      new Date(b.sys.firstPublishedAt).valueOf() -
+      new Date(a.sys.firstPublishedAt).valueOf()
+    );
+  });
+
   return (
     <>
       {router.isFallback ? (
@@ -75,7 +82,7 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
                   Posts by <strong>{authorInfo.name}</strong>
                 </p>
                 <div>
-                  {authorsPosts.map((post) => {
+                  {sortedDatePosts.map((post) => {
                     return (
                       <div key={post.slug}>
                         <PostsList key={post.sys.id} post={post} />

--- a/pages/blog/author/[author].tsx
+++ b/pages/blog/author/[author].tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 
 import Header from '../../../modules/shared/header';
 import PostsList from '../../../modules/blog/posts-list';
+import { PostSnippet } from '../../../modules/blog/post-snippet';
 
 import style from './author.module.scss';
 
@@ -13,29 +14,6 @@ import { getAllAuthors, getSingleAuthor } from '../../../lib/api';
 
 interface AuthorParams {
   author: string;
-}
-
-interface Post {
-  author: {
-    name: string;
-    picture: any;
-  };
-  content: {
-    json: any;
-    links: any;
-  };
-  coverImage: {
-    url: string;
-  };
-  date: string;
-  excerpt: string;
-  featuredPost: true;
-  secondaryPost: false;
-  slug: string;
-  sys: {
-    id: string;
-  };
-  title: string;
 }
 
 interface Author {
@@ -47,7 +25,7 @@ interface Author {
     };
     jobTitle: string;
   };
-  authorsPosts: Post[];
+  authorsPosts: PostSnippet[];
 }
 
 export default function Author({ authorInfo, authorsPosts }: Author) {

--- a/pages/blog/author/[author].tsx
+++ b/pages/blog/author/[author].tsx
@@ -85,9 +85,9 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
                 </div>
               </section>
 
-              <Link href="/blog" passHref>
-                <a>
-                  <div className={style.buttonWrapper}>
+              <div className={style.buttonWrapper}>
+                <Link href="/blog" passHref>
+                  <a>
                     <button className={style.backButton}>
                       <Image
                         alt="Back arrow"
@@ -97,9 +97,9 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
                       />
                       Back to Blog home
                     </button>
-                  </div>
-                </a>
-              </Link>
+                  </a>
+                </Link>
+              </div>
             </div>
           </article>
         </>

--- a/pages/blog/author/[author].tsx
+++ b/pages/blog/author/[author].tsx
@@ -100,26 +100,20 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
                   {authorsPosts.map((post) => {
                     return (
                       <div key={post.slug}>
-                        <Link href={`/blog/${post.slug}`}>
-                          <a>
-                            <PostsList key={post.sys.id} post={post} />
-                          </a>
-                        </Link>
+                        <PostsList key={post.sys.id} post={post} />
                       </div>
                     );
                   })}
                 </div>
               </section>
 
-              <div className={style.buttonWrapper}>
-                <Link href="/blog">
-                  <a>
-                    <button className={style.backButton}>
-                      Back to Blog home
-                    </button>
-                  </a>
-                </Link>
-              </div>
+              <Link href="/blog" passHref>
+                <div className={style.buttonWrapper}>
+                  <button className={style.backButton}>
+                    Back to Blog home
+                  </button>
+                </div>
+              </Link>
             </div>
           </article>
         </>

--- a/pages/blog/author/[author].tsx
+++ b/pages/blog/author/[author].tsx
@@ -2,8 +2,12 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import Head from 'next/head';
 import ErrorPage from 'next/error';
+import Image from 'next/image';
 
 import Header from '../../../modules/shared/header';
+import PostsList from '../../../modules/blog/posts-list';
+
+import style from './author.module.scss';
 
 import { getAllAuthors, getSingleAuthor } from '../../../lib/api';
 
@@ -37,9 +41,11 @@ interface Post {
 interface Author {
   authorInfo: {
     name: string;
+    bio: string;
     picture: {
       url: string;
     };
+    jobTitle: string;
   };
   authorsPosts: Post[];
 }
@@ -63,21 +69,56 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
               <meta property="og:image" content={authorInfo.picture.url} />
             </Head>
             <Header />
-            <h2 style={{ marginTop: 100 }}>
-              {authorInfo.name}&apos;s author page
-            </h2>
-            <div>
-              <p>Articles by them:</p>
-              <div>
-                {authorsPosts.map((post) => {
-                  return (
-                    <div key={post.slug}>
-                      <Link href={`/blog/${post.slug}`}>
-                        <a>{post.title}</a>
-                      </Link>
-                    </div>
-                  );
-                })}
+            <div className={style.authorWrapper}>
+              <section className={style.authorInfo}>
+                <div className={style.imageWrapper}>
+                  <Image
+                    src={authorInfo.picture.url}
+                    alt="author picture alt"
+                    width={160}
+                    height={160}
+                  />
+                </div>
+                {/* The contacts sections to be confirmed by the design team */}
+                {/* <div className={style.contacts}>
+                    <div className={style.circle} />
+                    <div className={style.circle} />
+                    <div className={style.circle} />
+                  </div> */}
+                <div className={style.info}>
+                  <p className={style.name}>{authorInfo.name}</p>
+                  <p className={style.jobTitle}>{authorInfo.jobTitle}</p>
+                </div>
+                <p className={style.bio}>{authorInfo.bio}</p>
+              </section>
+
+              <section className={style.blogsList}>
+                <p className={style.postsBy}>
+                  Posts by <strong>{authorInfo.name}</strong>
+                </p>
+                <div>
+                  {authorsPosts.map((post) => {
+                    return (
+                      <div key={post.slug}>
+                        <Link href={`/blog/${post.slug}`}>
+                          <a>
+                            <PostsList key={post.sys.id} post={post} />
+                          </a>
+                        </Link>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+
+              <div className={style.buttonWrapper}>
+                <Link href="/blog">
+                  <a>
+                    <button className={style.backButton}>
+                      Back to Blog home
+                    </button>
+                  </a>
+                </Link>
               </div>
             </div>
           </article>

--- a/pages/blog/author/[author].tsx
+++ b/pages/blog/author/[author].tsx
@@ -35,6 +35,13 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
     return <ErrorPage statusCode={404} />;
   }
 
+  const sortedDatePosts = authorsPosts?.sort((a, b) => {
+    return (
+      new Date(b.sys.firstPublishedAt).valueOf() -
+      new Date(a.sys.firstPublishedAt).valueOf()
+    );
+  });
+
   return (
     <>
       {router.isFallback ? (
@@ -75,7 +82,7 @@ export default function Author({ authorInfo, authorsPosts }: Author) {
                   Posts by <strong>{authorInfo.name}</strong>
                 </p>
                 <div>
-                  {authorsPosts.map((post) => {
+                  {sortedDatePosts.map((post) => {
                     return (
                       <div key={post.slug}>
                         <PostsList key={post.sys.id} post={post} />

--- a/pages/blog/author/author.module.scss
+++ b/pages/blog/author/author.module.scss
@@ -40,12 +40,14 @@
 
 .imageWrapper {
   border-radius: 50%;
-  height: 160px;
+  border: 4px solid $color-font;
+  box-shadow: 0px 12px 16px -4px rgba(16, 24, 40, 0.08),
+    0px 4px 6px -2px rgba(16, 24, 40, 0.03);
+  grid-area: imageWrapper;
+  height: 168px;
   overflow: hidden;
   position: relative;
-  width: 160px;
-  border: 4px solid $color-font;
-  grid-area: imageWrapper;
+  width: 168px;
 }
 
 .contacts {

--- a/pages/blog/author/author.module.scss
+++ b/pages/blog/author/author.module.scss
@@ -1,0 +1,119 @@
+@import '../../../styles/variables';
+@import '../../../styles/mixins';
+
+.authorWrapper {
+  margin: $header-height auto 0 auto;
+  max-width: $blog-max-content;
+}
+
+.authorInfo {
+  display: grid;
+  grid-template-columns: 24.5rem 50rem;
+  grid-template-areas:
+    'imageWrapper contacts'
+    'info bio';
+
+  column-gap: 1.5rem;
+  padding: 5rem 2rem;
+
+  @include breakpoint(medium-only) {
+    grid-template-columns: 12.5rem 42rem;
+    column-gap: 0.5rem;
+  }
+
+  @include breakpoint(small) {
+    grid-template-columns: auto auto;
+    grid-template-rows: auto;
+    grid-template-areas:
+      'imageWrapper contacts'
+      'info info'
+      'bio bio';
+  }
+}
+
+.authorInfo,
+.blogsList {
+  @include breakpoint(small) {
+    padding: 3rem 1rem 0 1rem;
+  }
+}
+
+.imageWrapper {
+  border-radius: 50%;
+  height: 160px;
+  overflow: hidden;
+  position: relative;
+  width: 160px;
+  border: 4px solid $color-font;
+  grid-area: imageWrapper;
+}
+
+.contacts {
+  display: flex;
+  gap: 1rem;
+  grid-area: contacts;
+  justify-content: flex-end;
+
+  @include breakpoint(small) {
+    align-items: end;
+    flex-direction: column;
+  }
+}
+
+.circle {
+  background-color: $color-white-500;
+  border-radius: 50%;
+  height: 40px;
+  overflow: hidden;
+  position: relative;
+  width: 40px;
+}
+
+.info {
+  grid-area: info;
+}
+
+.name {
+  @include display-xs();
+
+  font-weight: 500;
+  margin: 2rem 0 0 0;
+}
+
+.jobTitle {
+  @include text-xl();
+
+  margin: 0;
+}
+
+.bio {
+  @include text-xl();
+
+  color: $color-grey-900;
+  margin: 2rem 0 0;
+  grid-area: bio;
+}
+
+.postsBy {
+  @include text-xl();
+
+  padding: 0 2rem 3rem;
+
+  @include breakpoint(small) {
+    padding: 0;
+  }
+}
+
+.buttonWrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.backButton {
+  @include button($size: normal, $style: primary);
+  @include text-sm;
+
+  font-weight: 700;
+
+  margin: 4.5rem 0 7.5rem 0;
+}

--- a/pages/blog/author/author.module.scss
+++ b/pages/blog/author/author.module.scss
@@ -97,7 +97,8 @@
 .postsBy {
   @include text-xl();
 
-  padding: 0 2rem 3rem;
+  margin: 0;
+  padding: 0 2rem 2rem;
 
   @include breakpoint(small) {
     padding: 0;

--- a/pages/blog/author/author.module.scss
+++ b/pages/blog/author/author.module.scss
@@ -113,7 +113,10 @@
   @include button($size: normal, $style: primary);
   @include text-sm;
 
+  align-items: center;
   cursor: pointer;
+  display: flex;
   font-weight: 700;
+  gap: 0.8125rem;
   margin: 4.5rem 0 7.5rem 0;
 }

--- a/pages/blog/author/author.module.scss
+++ b/pages/blog/author/author.module.scss
@@ -113,7 +113,7 @@
   @include button($size: normal, $style: primary);
   @include text-sm;
 
+  cursor: pointer;
   font-weight: 700;
-
   margin: 4.5rem 0 7.5rem 0;
 }

--- a/pages/blog/author/author.module.scss
+++ b/pages/blog/author/author.module.scss
@@ -22,6 +22,7 @@
   }
 
   @include breakpoint(small) {
+    padding: 3rem 1rem 0 1rem;
     grid-template-columns: auto auto;
     grid-template-rows: auto;
     grid-template-areas:
@@ -31,10 +32,9 @@
   }
 }
 
-.authorInfo,
 .blogsList {
   @include breakpoint(small) {
-    padding: 3rem 1rem 0 1rem;
+    padding: 3.75rem 1rem 0 1rem;
   }
 }
 
@@ -101,6 +101,7 @@
 
   @include breakpoint(small) {
     padding: 0;
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
## Description
Fixes #83 
To include the author page in the blog section

## Development notes

Currently when I tried to include `coverImage` as part of the query , it throw errors as below
<img width="452" alt="Screenshot 2023-02-09 at 14 31 15" src="https://user-images.githubusercontent.com/32060364/217884069-55a47da5-e400-4c80-9573-2a581582c1e3.png">

So my quick solution now is to increase the limit in the query, though it's not the best fix. So I'm working on the other solution to fix this issue in the meantime

My current fix is:

```
const entries = await fetchGraphQL(
    `query {
      authorCollection(where: {urlDisplayName: "${author}"}, limit: 20) {
        items {
          ......
        }
      }
    }`
```



## QA notes

<!-- How has the expected behavior changed? What testing strategies have you used? Have you QAed your final work with the design team? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
