### PR TITLE
Update readthedocs links to docs.kedro.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 # misc
 .DS_Store
 public/.DS_Store
+.env*.local

--- a/components/features/features-content.tsx
+++ b/components/features/features-content.tsx
@@ -21,7 +21,7 @@ export const shownContent: FeatureProps[] = [
   },
   {
     assetPosition: 'right',
-    buttonLink: 'https://docs.kedro.org/en/stable/05_data/01_data_catalog.html',
+    buttonLink: 'https://docs.kedro.org/en/stable/data/data_catalog.html',
     buttonText: 'Explore the data catalog',
     iframeList: [
       {

--- a/components/features/features-content.tsx
+++ b/components/features/features-content.tsx
@@ -78,7 +78,7 @@ export const shownContent: FeatureProps[] = [
       },
     ],
     subtitle:
-      'You can standardise how configuration, source code, tests, documentation, and notebooks are organised with an adaptable, easy-to-use project template. <a href="https://docs.kedro.org/en/stable/07_extend_kedro/05_create_kedro_starters.html" rel="noopener noreferrer" target="_blank" >Create your cookie cutter project templates with Starters.',
+      'You can standardise how configuration, source code, tests, documentation, and notebooks are organised with an adaptable, easy-to-use project template. <a href="https://docs.kedro.org/en/stable/kedro_project_setup/starters.html" rel="noopener noreferrer" target="_blank" >Create your cookie cutter project templates with Starters.',
     title: 'Project Template',
   },
 ];

--- a/components/features/features-content.tsx
+++ b/components/features/features-content.tsx
@@ -21,8 +21,7 @@ export const shownContent: FeatureProps[] = [
   },
   {
     assetPosition: 'right',
-    buttonLink:
-      'https://kedro.readthedocs.io/en/stable/05_data/01_data_catalog.html',
+    buttonLink: 'https://docs.kedro.org/en/stable/05_data/01_data_catalog.html',
     buttonText: 'Explore the data catalog',
     iframeList: [
       {
@@ -63,7 +62,7 @@ export const shownContent: FeatureProps[] = [
   {
     assetPosition: 'right',
     buttonLink:
-      'https://kedro.readthedocs.io/en/stable/02_get_started/05_example_project.html#project-directory-structure',
+      'https://docs.kedro.org/en/stable/02_get_started/05_example_project.html#project-directory-structure',
     buttonText: 'View the project template',
     iframeList: [
       {
@@ -79,7 +78,7 @@ export const shownContent: FeatureProps[] = [
       },
     ],
     subtitle:
-      'You can standardise how configuration, source code, tests, documentation, and notebooks are organised with an adaptable, easy-to-use project template. <a href="https://kedro.readthedocs.io/en/stable/07_extend_kedro/05_create_kedro_starters.html" rel="noopener noreferrer" target="_blank" >Create your cookie cutter project templates with Starters.',
+      'You can standardise how configuration, source code, tests, documentation, and notebooks are organised with an adaptable, easy-to-use project template. <a href="https://docs.kedro.org/en/stable/07_extend_kedro/05_create_kedro_starters.html" rel="noopener noreferrer" target="_blank" >Create your cookie cutter project templates with Starters.',
     title: 'Project Template',
   },
 ];
@@ -89,7 +88,7 @@ export const hiddenContent: FeatureProps[] = [
     assetClassName: 'pipelineAbstraction',
     assetPosition: 'left',
     buttonLink:
-      'https://kedro.readthedocs.io/en/stable/06_nodes_and_pipelines/02_pipeline_introduction.html',
+      'https://docs.kedro.org/en/stable/06_nodes_and_pipelines/02_pipeline_introduction.html',
     buttonText: 'Build a pipeline',
     iframeList: [
       {
@@ -130,7 +129,7 @@ export const hiddenContent: FeatureProps[] = [
     altText: 'Flexible Deployment example',
     assetPosition: 'left',
     buttonLink:
-      'https://kedro.readthedocs.io/en/stable/10_deployment/01_deployment_guide.html',
+      'https://docs.kedro.org/en/stable/10_deployment/01_deployment_guide.html',
     buttonText: 'Choose your deployment target',
     imageSrc: flexibleDeployment,
     subtitle:
@@ -141,7 +140,7 @@ export const hiddenContent: FeatureProps[] = [
     altText: 'Experiment Tracking example',
     assetPosition: 'right',
     buttonLink:
-      'https://kedro.readthedocs.io/en/latest/visualisation/experiment_tracking.html',
+      'https://docs.kedro.org/en/stable/visualisation/experiment_tracking.html',
     buttonText: 'Enable experiment tracking',
     imageSrc: expTracking,
     subtitle:

--- a/components/features/features-content.tsx
+++ b/components/features/features-content.tsx
@@ -88,7 +88,7 @@ export const hiddenContent: FeatureProps[] = [
     assetClassName: 'pipelineAbstraction',
     assetPosition: 'left',
     buttonLink:
-      'https://docs.kedro.org/en/stable/06_nodes_and_pipelines/02_pipeline_introduction.html',
+      'https://docs.kedro.org/en/stable/nodes_and_pipelines/pipeline_introduction.html',
     buttonText: 'Build a pipeline',
     iframeList: [
       {

--- a/components/features/features-content.tsx
+++ b/components/features/features-content.tsx
@@ -129,7 +129,7 @@ export const hiddenContent: FeatureProps[] = [
     altText: 'Flexible Deployment example',
     assetPosition: 'left',
     buttonLink:
-      'https://docs.kedro.org/en/stable/10_deployment/01_deployment_guide.html',
+      'https://docs.kedro.org/en/stable/deployment/deployment_guide.html',
     buttonText: 'Choose your deployment target',
     imageSrc: flexibleDeployment,
     subtitle:

--- a/components/features/features-content.tsx
+++ b/components/features/features-content.tsx
@@ -62,7 +62,7 @@ export const shownContent: FeatureProps[] = [
   {
     assetPosition: 'right',
     buttonLink:
-      'https://docs.kedro.org/en/stable/02_get_started/05_example_project.html#project-directory-structure',
+      'https://docs.kedro.org/en/stable/get_started/kedro_concepts.html#kedro-project-directory-structure',
     buttonText: 'View the project template',
     iframeList: [
       {

--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -24,7 +24,7 @@ export default function Footer() {
           </a>
           <a
             className={style.link}
-            href="https://docs.kedro.org/en/stable/02_get_started/01_prerequisites.html"
+            href="https://docs.kedro.org/en/stable/get_started/install.html"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -24,14 +24,14 @@ export default function Footer() {
           </a>
           <a
             className={style.link}
-            href="https://kedro.readthedocs.io/en/stable/02_get_started/01_prerequisites.html"
+            href="https://docs.kedro.org/en/stable/02_get_started/01_prerequisites.html"
             rel="noopener noreferrer"
             target="_blank"
           >
             Get Started
           </a>
           <a
-            href="https://kedro.readthedocs.io/en/stable/"
+            href="https://docs.kedro.org/en/stable/"
             className={style.link}
             target="_blank"
             rel="noopener noreferrer"

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
           </a>
           <a
             className={style.link}
-            href="https://docs.kedro.org/en/stable/02_get_started/01_prerequisites.html"
+            href="https://docs.kedro.org/en/stable/get_started/install.html"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
           </a>
           <a
             className={style.link}
-            href="https://kedro.readthedocs.io/en/stable/02_get_started/01_prerequisites.html"
+            href="https://docs.kedro.org/en/stable/02_get_started/01_prerequisites.html"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -38,7 +38,7 @@ export default function Header() {
           </a>
           <a
             className={style.link}
-            href="https://kedro.readthedocs.io/en/stable/"
+            href="https://docs.kedro.org/en/stable/"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/components/hero/hero.tsx
+++ b/components/hero/hero.tsx
@@ -112,7 +112,7 @@ export default function Hero() {
               </a>
             </motion.div>
             <a
-              href="https://docs.kedro.org/en/stable/03_tutorial/01_spaceflights_tutorial.html"
+              href="https://docs.kedro.org/en/stable/tutorial/spaceflights_tutorial.html"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/components/hero/hero.tsx
+++ b/components/hero/hero.tsx
@@ -85,7 +85,7 @@ export default function Hero() {
               whileHover="hover"
             >
               <a
-                href="https://docs.kedro.org/en/stable/02_get_started/01_prerequisites.html"
+                href="https://docs.kedro.org/en/stable/get_started/install.html"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/components/hero/hero.tsx
+++ b/components/hero/hero.tsx
@@ -85,7 +85,7 @@ export default function Hero() {
               whileHover="hover"
             >
               <a
-                href="https://kedro.readthedocs.io/en/stable/02_get_started/01_prerequisites.html"
+                href="https://docs.kedro.org/en/stable/02_get_started/01_prerequisites.html"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -112,7 +112,7 @@ export default function Hero() {
               </a>
             </motion.div>
             <a
-              href="https://kedro.readthedocs.io/en/stable/03_tutorial/01_spaceflights_tutorial.html"
+              href="https://docs.kedro.org/en/stable/03_tutorial/01_spaceflights_tutorial.html"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/components/ready-to-start/ready-to-start.tsx
+++ b/components/ready-to-start/ready-to-start.tsx
@@ -16,7 +16,7 @@ export default function ReadyToStart() {
             our introductory tutorial.
           </p>
           <a
-            href="https://kedro.readthedocs.io/en/stable/02_get_started/01_prerequisites.html"
+            href="https://docs.kedro.org/en/stable/02_get_started/01_prerequisites.html"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/components/ready-to-start/ready-to-start.tsx
+++ b/components/ready-to-start/ready-to-start.tsx
@@ -16,7 +16,7 @@ export default function ReadyToStart() {
             our introductory tutorial.
           </p>
           <a
-            href="https://docs.kedro.org/en/stable/02_get_started/01_prerequisites.html"
+            href="https://docs.kedro.org/en/stable/get_started/install.html"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/package-lock.json
+++ b/package-lock.json
@@ -7387,6 +7387,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz",
+      "integrity": "sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {
@@ -12877,6 +12892,12 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz",
+      "integrity": "sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==",
+      "optional": true
     }
   }
 }


### PR DESCRIPTION
## Description

Since we now have docs.kedro.org, the readthedocs domain can be swapped with our subdomain.

## QA notes

Ensure the new URLs bring you to the correct pages on the docs website.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
