### PR TITLE
Small image improvements

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -7,6 +7,10 @@ sys {
 slug
 title
 coverImage {
+  title
+  url
+}
+socialImage {
   url
 }
 category
@@ -85,6 +89,7 @@ sys {
 slug
 title
 coverImage {
+  title
   url
 }
 category

--- a/modules/blog/post-snippet/post-snippet.tsx
+++ b/modules/blog/post-snippet/post-snippet.tsx
@@ -13,6 +13,7 @@ export type PostSnippet = {
   author: Author;
   category: string;
   coverImage: {
+    title: string;
     url: string;
   };
   date: string;
@@ -161,8 +162,9 @@ const PostSnippet = ({
         }}
       >
         <Image
-          alt="cover image alt"
+          alt={post.coverImage.title || 'Generic image for blog post'}
           height={imgSize}
+          objectFit="cover"
           src={post.coverImage.url}
           width={imgSize}
         />

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -40,7 +40,6 @@ type Post = {
 };
 
 export default function Post({ post, morePosts, preview, slug }: Post) {
-  console.log('post: ', post);
   const [isCopyLinkSelected, setIsCopyLinkSelected] = useState(false);
   const router = useRouter();
   const postUrl = post?.slug

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -40,6 +40,7 @@ type Post = {
 };
 
 export default function Post({ post, morePosts, preview, slug }: Post) {
+  console.log('post: ', post);
   const [isCopyLinkSelected, setIsCopyLinkSelected] = useState(false);
   const router = useRouter();
   const postUrl = post?.slug


### PR DESCRIPTION
## Description

Fixes:

- The social image for the post not being used
- The `PostSnippet` component now preserves the image's aspect ratio
- Better `alt` text for images

## QA notes

Take a look at the deployed URL and view the images. They're not being cropped. Also, if you share the post URL via Slack, the correct social image should appear.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
