### PR TITLE
Add blog link to header

### DIFF
--- a/modules/shared/header/header.test.tsx
+++ b/modules/shared/header/header.test.tsx
@@ -20,7 +20,7 @@ describe('Header', () => {
   it('displays the correct number of links', async () => {
     render(<Header />);
 
-    expect(screen.getAllByRole('link')).toHaveLength(8);
+    expect(screen.getAllByRole('link')).toHaveLength(9);
   });
 
   it('opens and closes the menu when burger/close icon clicked', async () => {

--- a/modules/shared/header/header.tsx
+++ b/modules/shared/header/header.tsx
@@ -50,9 +50,9 @@ export default function Header() {
           >
             Documentation
           </a>
-          {/* <Link href="/blog">
+          <Link href="/blog">
             <a className={style.link}>Blog</a>
-          </Link> */}
+          </Link>
           <div className={style.iconLinks}>
             <a
               className={style.link}


### PR DESCRIPTION
## Description

We want people to be able to discover the blog, so let's add the link to the header.

## QA notes

It looks like this. Are we ok with the placement? 

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/16869061/228514492-31f025c3-f514-488e-bc88-e17d18f2277b.png">


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
