### PR TITLE
Add YouTube videos to blog post pages

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -62,6 +62,12 @@ content {
           }
           name
         }
+        ... on Video {
+          title
+          description
+          videoId
+          showControls
+        }
       }
     }
     assets {

--- a/modules/blog/post-body/post-body.module.scss
+++ b/modules/blog/post-body/post-body.module.scss
@@ -192,6 +192,16 @@
   }
 }
 
+.postBodyVideoCaption {
+  @include breakpoint(medium-up) {
+    margin-top: -4.1rem;
+  }
+
+  @include breakpoint(small) {
+    margin-top: -2.6rem;
+  }
+}
+
 .postBodyCallout {
   background-color: $color-white-100;
   border-radius: 1rem;

--- a/modules/blog/post-body/post-body.module.scss
+++ b/modules/blog/post-body/post-body.module.scss
@@ -158,13 +158,37 @@
   @include breakpoint(small) {
     margin: 3rem 0;
   }
+}
 
-  .postBodyImgCaption {
-    @include text-sm;
+.postBodyVideoWrapper {
+  height: 0;
+  overflow: hidden;
+  padding-bottom: 56.25%;
+  position: relative;
 
-    > p {
-      margin: 0;
-    }
+  @include breakpoint(medium-up) {
+    margin: 4.5rem 0;
+  }
+
+  @include breakpoint(small) {
+    margin: 3rem 0;
+  }
+
+  > iframe {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+}
+
+.postBodyImgCaption,
+.postBodyVideoCaption {
+  @include text-sm;
+
+  > p {
+    margin: 0;
   }
 }
 

--- a/modules/blog/post-body/post-body.tsx
+++ b/modules/blog/post-body/post-body.tsx
@@ -135,22 +135,24 @@ const renderOptions = (links: Links) => {
 
         if (entry.__typename === 'Video') {
           return (
-            <div className={style.postBodyVideoWrapper}>
-              <iframe
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                allowFullScreen
-                frameBorder="0"
-                src={`https://www.youtube.com/embed/${
-                  entry.videoId
-                }?controls=${+entry.showControls}`}
-                title="YouTube video player"
-              />
+            <>
+              <div className={style.postBodyVideoWrapper}>
+                <iframe
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  allowFullScreen
+                  frameBorder="0"
+                  src={`https://www.youtube.com/embed/${
+                    entry.videoId
+                  }?controls=${+entry.showControls}`}
+                  title="YouTube video player"
+                />
+              </div>
               {entry.description ? (
                 <div className={style.postBodyVideoCaption}>
-                  entry.description
+                  {entry.description}
                 </div>
               ) : null}
-            </div>
+            </>
           );
         }
       },

--- a/modules/blog/post-body/post-body.tsx
+++ b/modules/blog/post-body/post-body.tsx
@@ -132,19 +132,40 @@ const renderOptions = (links: Links) => {
             </div>
           );
         }
+
+        if (entry.__typename === 'Video') {
+          return (
+            <div className={style.postBodyVideoWrapper}>
+              <iframe
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowFullScreen
+                frameBorder="0"
+                src={`https://www.youtube.com/embed/${
+                  entry.videoId
+                }?controls=${+entry.showControls}`}
+                title="YouTube video player"
+              />
+              {entry.description ? (
+                <div className={style.postBodyVideoCaption}>
+                  entry.description
+                </div>
+              ) : null}
+            </div>
+          );
+        }
       },
       [BLOCKS.EMBEDDED_ASSET]: (node: Node) => {
         const asset = assetMap.get(node.data.target.sys.id);
 
         return (
-          <div className={style.postBodyImgWrapper}>
+          <div className={style.postBodyMediaWrapper}>
             <Image
               alt={asset.description}
               height={asset.height}
               src={asset.url}
               width={asset.width}
             />
-            <div className={style.postBodyImgCaption}>{asset.title}</div>
+            <div className={style.postBodyMediaCaption}>{asset.title}</div>
           </div>
         );
       },

--- a/modules/blog/post-body/post-body.tsx
+++ b/modules/blog/post-body/post-body.tsx
@@ -158,14 +158,14 @@ const renderOptions = (links: Links) => {
         const asset = assetMap.get(node.data.target.sys.id);
 
         return (
-          <div className={style.postBodyMediaWrapper}>
+          <div className={style.postBodyImgWrapper}>
             <Image
               alt={asset.description}
               height={asset.height}
               src={asset.url}
               width={asset.width}
             />
-            <div className={style.postBodyMediaCaption}>{asset.title}</div>
+            <div className={style.postBodyImgCaption}>{asset.title}</div>
           </div>
         );
       },


### PR DESCRIPTION
## Description

Resolves #103.

## Development notes

I've added a `Video` content type to Contentful. That's consumed on the frontend and displayed inline in blog post pages.

<img width="1134" alt="image" src="https://user-images.githubusercontent.com/16869061/233482645-0add03c7-abe8-4361-9d0d-063b698a9369.png">


## QA notes

Before, with Jo's workaround (video thumbnail with caption linked to YouTube): 

<img width="983" alt="Screenshot 2023-04-20 at 17 55 34" src="https://user-images.githubusercontent.com/16869061/233481056-b0ea1b15-16c3-417c-a81e-018c57fb4b15.png">

Direct YouTube embed:

<img width="977" alt="Screenshot 2023-04-20 at 21 28 07" src="https://user-images.githubusercontent.com/16869061/233481166-82ac7136-7e42-4ede-9828-d4e837bd78e6.png">


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
