### PR TITLE
Add blog preview mode

### DIFF
--- a/pages/api/exit-preview.js
+++ b/pages/api/exit-preview.js
@@ -1,8 +1,0 @@
-export default async function exit(_, res) {
-  // Exit the current user from "Preview Mode". This function accepts no args.
-  res.clearPreviewData();
-
-  // Redirect the user back to the index page.
-  res.writeHead(307, { Location: '/' });
-  res.end();
-}

--- a/pages/api/exit-preview.ts
+++ b/pages/api/exit-preview.ts
@@ -1,0 +1,10 @@
+import { NextApiResponse } from 'next';
+
+export default async function exit(_: any, res: NextApiResponse) {
+  // Exit the current user from "Preview Mode". This function accepts no args.
+  res.clearPreviewData();
+
+  // Redirect the user back to the blog homepage.
+  res.writeHead(307, { Location: '/blog' });
+  res.end();
+}

--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -1,6 +1,10 @@
+import { NextApiRequest, NextApiResponse } from 'next';
 import { getPreviewPostBySlug } from '../../lib/api';
 
-export default async function preview(req, res) {
+export default async function preview(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   const { secret, slug } = req.query;
 
   if (secret !== process.env.CONTENTFUL_PREVIEW_SECRET || !slug) {

--- a/pages/api/revalidate.ts
+++ b/pages/api/revalidate.ts
@@ -1,6 +1,9 @@
-// pages/api/revalidate.js
+import { NextApiRequest, NextApiResponse } from 'next';
 
-export default async function handler(req, res) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   // should be secret, custom header coming in from Contentful
   let inboundRevalToken = req.headers['x-vercel-reval-key'];
 

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import classNames from 'classnames';
 import { getAllPostsWithSlug, getPostAndMorePosts } from '../../lib/api';
 import { siteMetadata } from '../../modules/shared/config';
 
@@ -79,46 +78,40 @@ export default function Post({ post, morePosts, preview, slug }: Post) {
         <div>Loading…</div>
       ) : (
         <>
+          <Head>
+            <title>{post.title} | Kedro Blog</title>
+            <meta
+              name="description"
+              content={post.excerpt || siteMetadata.socialDescription}
+            />
+            <meta property="og:title" content={`${post.title} | Kedro Blog`} />
+            <meta property="og:type" content="website" />
+            <meta
+              property="og:image"
+              content={post.socialImage?.url || siteMetadata.socialImage}
+            />
+            <meta property="og:url" content={postUrl || siteMetadata.baseUrl} />
+            <meta
+              content={post.excerpt || siteMetadata.socialDescription}
+              property="og:description"
+            />
+            <meta property="og:site_name" content="Kedro" />
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta
+              content={siteMetadata.socialDescription}
+              name="twitter:image:alt"
+            />
+            <meta
+              content={post.socialImage?.url || siteMetadata.socialImage}
+              name="twitter:image"
+            ></meta>
+            <meta name="twitter:title" content={post.title}></meta>
+            <meta
+              name="twitter:description"
+              content={post.excerpt || siteMetadata.socialDescription}
+            ></meta>
+          </Head>
           <article>
-            <Head>
-              <title>{post.title} | Kedro Blog</title>
-              <meta
-                name="description"
-                content={post.excerpt || siteMetadata.socialDescription}
-              />
-              <meta
-                property="og:title"
-                content={`${post.title} | Kedro Blog`}
-              />
-              <meta property="og:type" content="website" />
-              <meta
-                property="og:image"
-                content={post.socialImage?.url || siteMetadata.socialImage}
-              />
-              <meta
-                property="og:url"
-                content={postUrl || siteMetadata.baseUrl}
-              />
-              <meta
-                content={post.excerpt || siteMetadata.socialDescription}
-                property="og:description"
-              />
-              <meta property="og:site_name" content="Kedro" />
-              <meta name="twitter:card" content="summary_large_image" />
-              <meta
-                content={siteMetadata.socialDescription}
-                name="twitter:image:alt"
-              />
-              <meta
-                content={post.socialImage?.url || siteMetadata.socialImage}
-                name="twitter:image"
-              ></meta>
-              <meta name="twitter:title" content={post.title}></meta>
-              <meta
-                name="twitter:description"
-                content={post.excerpt || siteMetadata.socialDescription}
-              ></meta>
-            </Head>
             <Header />
             <section className={style.featuredOuter}>
               <div className={style.featuredInner}>
@@ -205,6 +198,15 @@ export default function Post({ post, morePosts, preview, slug }: Post) {
               </section>
             ) : null}
           </article>
+          {preview ? (
+            <div className={style.pagePreviewWrapper}>
+              This page is a preview.{' '}
+              <strong>
+                <Link href="/api/exit-preview">Click here</Link>
+              </strong>{' '}
+              to exit preview mode.
+            </div>
+          ) : null}
         </>
       )}
       <style jsx global>{`

--- a/pages/post.module.scss
+++ b/pages/post.module.scss
@@ -138,3 +138,18 @@
     }
   }
 }
+
+.pagePreviewWrapper {
+  background-color: $color-accent;
+  border-radius: 5px;
+  border: 2px solid $color-dark;
+  bottom: 10px;
+  padding: 10px;
+  position: fixed;
+  right: 10px;
+  z-index: 10;
+
+  > strong {
+    text-decoration: underline;
+  }
+}


### PR DESCRIPTION
## Description

Resolves #102.

## Development notes

Follows some of the Next.js documentation [here](https://nextjs.org/docs/advanced-features/preview-mode).

## QA notes

If a post in Contentful is in the `Changed` or `Draft` state, you'll be able to preview it by clicking on this button in the editor: 

<img width="372" alt="image" src="https://user-images.githubusercontent.com/16869061/233976697-0a7b76f6-6aac-4d89-9086-66d2a7f57446.png">

Doing that will set a cookie that shows the blog in preview mode. You'll need to exit that mode at some point to view the blog as a normal user would. To do so, click the link in the alert box at the bottom of the page:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/16869061/233976957-db275777-052e-47c8-a419-d956b72f96ac.png">

That will clear the relevant cookie and return you to the default viewing state.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
