### PR TITLE
Update header underline thickness on hover

### DIFF
--- a/modules/blog/post-snippet/post-snippet.module.scss
+++ b/modules/blog/post-snippet/post-snippet.module.scss
@@ -58,6 +58,7 @@ $gap-mobile-version: 1rem;
     color: $color-font;
     font-weight: 500;
     margin-top: $gap;
+    text-decoration-thickness: 3px;
 
     &.titleOnPostPage {
       color: $color-dark;
@@ -78,6 +79,7 @@ $gap-mobile-version: 1rem;
 
     color: $color-grey-200;
     margin: $gap 0;
+    text-decoration-thickness: 1px;
 
     &.descriptionOnPostPage {
       color: $color-grey-900;


### PR DESCRIPTION
## Description

This solves a point raised by Jo on Slack.

## QA notes

Hover over the feature story's headline and notice the underline isn't as invasive.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
