### PR TITLE
Add AsciinemaCapture to blog posts

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -58,6 +58,12 @@ content {
           }
           title
         }
+        ... on AsciinemaCapture {
+          description
+          castFile {
+            url
+          }
+        }
         ... on Media {
           caption {
             json

--- a/modules/blog/asciinema-player/AsciinemaPlayer.tsx
+++ b/modules/blog/asciinema-player/AsciinemaPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import 'asciinema-player/dist/bundle/asciinema-player.css';
 
 type AsciinemaPlayerProps = {

--- a/modules/blog/asciinema-player/AsciinemaPlayer.tsx
+++ b/modules/blog/asciinema-player/AsciinemaPlayer.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useRef, useState } from 'react';
+import 'asciinema-player/dist/bundle/asciinema-player.css';
+
+type AsciinemaPlayerProps = {
+  src: string;
+  autoPlay?: boolean;
+  cols?: string;
+  fit?: string;
+  fontSize?: string;
+  idleTimeLimit?: number;
+  loop?: boolean | number;
+  poster?: string;
+  preload?: boolean;
+  rows?: string;
+  speed?: number;
+  startAt?: number | string;
+  theme?: string;
+};
+
+function AsciinemaPlayer({ src, ...asciinemaOptions }: AsciinemaPlayerProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [player, setPlayer] = useState<typeof import('asciinema-player')>();
+
+  useEffect(() => {
+    import('asciinema-player').then((player) => {
+      setPlayer(player);
+    });
+  }, []);
+
+  useEffect(() => {
+    const currentRef = ref.current;
+    const instance = player?.create(src, currentRef, asciinemaOptions);
+
+    return () => {
+      instance?.dispose();
+    };
+  }, [src, player, asciinemaOptions]);
+
+  return <div ref={ref} />;
+}
+
+export default AsciinemaPlayer;

--- a/modules/blog/asciinema-player/asciinema-player.d.ts
+++ b/modules/blog/asciinema-player/asciinema-player.d.ts
@@ -1,0 +1,20 @@
+declare module 'asciinema-player' {
+  export function create(
+    src: string,
+    element: HTMLElement | null,
+    opts: {
+      autoPlay?: boolean;
+      cols?: string;
+      fit?: string;
+      fontSize?: string;
+      idleTimeLimit?: number;
+      loop?: boolean | number;
+      poster?: string;
+      preload?: boolean;
+      rows?: string;
+      speed?: number;
+      startAt?: number | string;
+      theme?: string;
+    }
+  );
+}

--- a/modules/blog/asciinema-player/index.ts
+++ b/modules/blog/asciinema-player/index.ts
@@ -1,0 +1,3 @@
+import AsciinemaPlayer from './AsciinemaPlayer';
+
+export default AsciinemaPlayer;

--- a/modules/blog/post-body/post-body.tsx
+++ b/modules/blog/post-body/post-body.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
 import classNames from 'classnames';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 import { BLOCKS, Document, INLINES } from '@contentful/rich-text-types';
@@ -10,8 +12,7 @@ import {
   scrollToTargetAdjusted,
 } from '../../../utils/blog';
 
-import Image from 'next/image';
-import Link from 'next/link';
+import AsciinemaPlayer from '../asciinema-player';
 
 import style from './post-body.module.scss';
 
@@ -199,7 +200,6 @@ const renderOptions = (
                 <iframe
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                   allowFullScreen
-                  frameBorder="0"
                   src={`https://www.youtube.com/embed/${
                     entry.videoId
                   }?controls=${+entry.showControls}&start=${entry.startAt}`}
@@ -213,6 +213,10 @@ const renderOptions = (
               ) : null}
             </>
           );
+        }
+
+        if (entry.__typename === 'AsciinemaCapture') {
+          return <AsciinemaPlayer src={entry.castFile.url} />;
         }
       },
       [BLOCKS.EMBEDDED_ASSET]: (node: Node) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@testing-library/react": "^14.0.0",
         "@types/react": "^18.0.38",
         "@types/react-syntax-highlighter": "^15.5.6",
+        "asciinema-player": "^3.6.3",
         "contentful-import": "^8.5.0",
         "eslint": "8.8.0",
         "eslint-config-next": "12.0.10",
@@ -2602,6 +2603,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asciinema-player": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/asciinema-player/-/asciinema-player-3.6.3.tgz",
+      "integrity": "sha512-62aDgLpbuduhmpFfNgPOzf6fOluACLsftVnjpWJjUXX6dqhqTckFqWoJ+ayA0XjSlZ9l9wXTcJqRqvAAIpMblg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "solid-js": "^1.3.0"
       }
     },
     "node_modules/ast-types-flow": {
@@ -10597,6 +10608,27 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/seroval": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.0.4.tgz",
+      "integrity": "sha512-qQs/N+KfJu83rmszFQaTxcoJoPn6KNUruX4KmnmyD0oZkUoiNvJ1rpdYKDf4YHM05k+HOgCxa3yvf15QbVijGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.0.4.tgz",
+      "integrity": "sha512-DQ2IK6oQVvy8k+c2V5x5YCtUa/GGGsUwUBNN9UqohrZ0rWdUapBFpNMYP1bCyRHoxOJjdKGl+dieacFIpU/i1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
     "node_modules/set-function-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -10674,6 +10706,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/solid-js": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.8.12.tgz",
+      "integrity": "sha512-sLE/i6M9FSWlov3a2pTC5ISzanH2aKwqXTZj+bbFt4SUrVb4iGEa7fpILBMOxsQjkv3eXqEk6JVLlogOdTe0UQ==",
+      "dev": true,
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "^1.0.3",
+        "seroval-plugins": "^1.0.3"
       }
     },
     "node_modules/source-map": {
@@ -14036,6 +14079,16 @@
         "get-intrinsic": "^1.2.1",
         "is-array-buffer": "^3.0.2",
         "is-shared-array-buffer": "^1.0.2"
+      }
+    },
+    "asciinema-player": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/asciinema-player/-/asciinema-player-3.6.3.tgz",
+      "integrity": "sha512-62aDgLpbuduhmpFfNgPOzf6fOluACLsftVnjpWJjUXX6dqhqTckFqWoJ+ayA0XjSlZ9l9wXTcJqRqvAAIpMblg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.21.0",
+        "solid-js": "^1.3.0"
       }
     },
     "ast-types-flow": {
@@ -19870,6 +19923,19 @@
         }
       }
     },
+    "seroval": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.0.4.tgz",
+      "integrity": "sha512-qQs/N+KfJu83rmszFQaTxcoJoPn6KNUruX4KmnmyD0oZkUoiNvJ1rpdYKDf4YHM05k+HOgCxa3yvf15QbVijGg==",
+      "dev": true
+    },
+    "seroval-plugins": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.0.4.tgz",
+      "integrity": "sha512-DQ2IK6oQVvy8k+c2V5x5YCtUa/GGGsUwUBNN9UqohrZ0rWdUapBFpNMYP1bCyRHoxOJjdKGl+dieacFIpU/i1A==",
+      "dev": true,
+      "requires": {}
+    },
     "set-function-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -19930,6 +19996,17 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==",
       "dev": true
+    },
+    "solid-js": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.8.12.tgz",
+      "integrity": "sha512-sLE/i6M9FSWlov3a2pTC5ISzanH2aKwqXTZj+bbFt4SUrVb4iGEa7fpILBMOxsQjkv3eXqEk6JVLlogOdTe0UQ==",
+      "dev": true,
+      "requires": {
+        "csstype": "^3.1.0",
+        "seroval": "^1.0.3",
+        "seroval-plugins": "^1.0.3"
+      }
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@testing-library/react": "^14.0.0",
     "@types/react": "^18.0.38",
     "@types/react-syntax-highlighter": "^15.5.6",
+    "asciinema-player": "^3.6.3",
     "contentful-import": "^8.5.0",
     "eslint": "8.8.0",
     "eslint-config-next": "12.0.10",


### PR DESCRIPTION
## Description

Resolves #185 

## Development notes

I've added a `<AsciinemaPlayer />` component and accompanying NPM [package](https://github.com/asciinema/asciinema-player).

I've also created a new content type in Contentful for this specific purpose. It's called **Asciinema Capture**. You have to download the `.cast` file and upload that to Contentful. That was the only way I could get this to work via their library.

## QA notes

Here's a screenshot: 

![image](https://github.com/kedro-org/kedro-website/assets/16869061/435a1c7f-8772-472c-b068-4a24bb1a4321)


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
