### PR TITLE
Update Features: Coding Standards section

### DIFF
--- a/modules/index/features/features-content.tsx
+++ b/modules/index/features/features-content.tsx
@@ -122,7 +122,7 @@ export const hiddenContent: FeatureProps[] = [
       },
     ],
     subtitle:
-      'Test-driven development using <a href="https://github.com/pytest-dev/pytest" rel="noopener noreferrer" target="_blank">pytest</a>, produce well-documented code using <a href="http://www.sphinx-doc.org/en/master/" rel="noopener noreferrer" target="_blank">Sphinx</a>, create linted code with support for <a href="https://github.com/PyCQA/flake8" rel="noopener noreferrer" target="_blank">flake8</a>, <a href="https://github.com/PyCQA/isort" rel="noopener noreferrer" target="_blank">isort</a> and <a href="https://github.com/psf/black" rel="noopener noreferrer" target="_blank">black</a> and make use of the standard Python logging library.',
+      'Test-driven development using <a href="https://github.com/pytest-dev/pytest" rel="noopener noreferrer" target="_blank">pytest</a>, produce well-documented code using <a href="http://www.sphinx-doc.org/en/master/" rel="noopener noreferrer" target="_blank">Sphinx</a>, create linted code with <a href="https://docs.astral.sh/ruff/" rel="noopener noreferrer" target="_blank">ruff</a> and make use of the standard Python logging library.',
     title: 'Coding Standards',
   },
   {


### PR DESCRIPTION
## Description
A user noticed that the website "Features" page does not seem up-to-date. Section 05 "Coding Standards" mentions that the kedro template uses flake8, isort, and black but we have moved to using ruff.

## Development notes
Updated the description for coding standards.


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Added tests to cover my changes, where applicable
