### PR TITLE
Manage AI crawlers

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -7,11 +7,11 @@
       "ChatGPT-User",
       "Claude-Web",
       "ClaudeBot",
-      "PerplexityBot"
+      "PerplexityBot",
+      "anthropic-ai"
     ],
     "disallowed": [
       "AI2Bot",
-      "anthropic-ai",
       "AwarioRssBot",
       "AwarioSmartBot",
       "Bytespider",

--- a/agents.json
+++ b/agents.json
@@ -4,11 +4,12 @@
       "Bingbot",
       "Applebot",
       "ChatGPT",
-      "ChatGPT-User"
-    ],
-    "disallowed": [
+      "ChatGPT-User",
       "Claude-Web",
       "ClaudeBot",
+      "PerplexityBot"
+    ],
+    "disallowed": [
       "AI2Bot",
       "anthropic-ai",
       "AwarioRssBot",
@@ -16,7 +17,6 @@
       "Bytespider",
       "CCBot",
       "diffbot",
-      "PerplexityBot",
       "Omgili",
       "ImagesiftBot",
       "Youbot",

--- a/agents.json
+++ b/agents.json
@@ -1,0 +1,37 @@
+{
+    "allowed": [
+      "Googlebot",
+      "Bingbot",
+      "Applebot",
+      "ChatGPT",
+      "ChatGPT-User"
+    ],
+    "disallowed": [
+      "Claude-Web",
+      "ClaudeBot",
+      "AI2Bot",
+      "anthropic-ai",
+      "AwarioRssBot",
+      "AwarioSmartBot",
+      "Bytespider",
+      "CCBot",
+      "diffbot",
+      "PerplexityBot",
+      "Omgili",
+      "ImagesiftBot",
+      "Youbot",
+      "Applebot-Extended",
+      "Facebookbot",
+      "FacebookBot",
+      "Meta-ExternalAgent",
+      "Meta-ExternalFetcher",
+      "Kangaroo Bot",
+      "Timpibot",
+      "Webzio-Extended",
+      "DuckAssistBot",
+      "OAI-SearchBot",
+      "Amazonbot",
+      "Google-Extended"
+    ]
+  }
+  

--- a/generateRobotsTxt.js
+++ b/generateRobotsTxt.js
@@ -1,5 +1,8 @@
-// Import the file system module
 const fileSystem = require('fs');
+const path = require('path');
+
+// Path to the existing robots.txt file
+const robotsFilePath = path.join(__dirname, 'public', 'robots.txt');
 
 // Import the merged agents file
 const agents = require('./agents.json');
@@ -16,11 +19,25 @@ agents.disallowed.forEach(userAgent => {
   rules.push(`User-agent: ${userAgent}\nDisallow: /`);
 });
 
-// Write the combined rules to a robots.txt file
-fileSystem.writeFile('./robots.txt', rules.join("\n\n"), err => {
+// Combine the rules into a single string
+const customRules = rules.join("\n\n");
+
+// Read the existing robots.txt file
+fileSystem.readFile(robotsFilePath, 'utf8', (err, existingContent) => {
   if (err) {
-    console.error(err);
-  } else {
-    console.log("robots.txt file generated");
+    console.error('Error reading robots.txt:', err);
+    return;
   }
+
+  // Merge the existing content with your custom rules
+  const mergedContent = `${customRules.trim()}\n\n${existingContent.trim()}\n`;
+
+  // Write the merged content back to robots.txt
+  fileSystem.writeFile(robotsFilePath, mergedContent, 'utf8', err => {
+    if (err) {
+      console.error('Error writing to robots.txt:', err);
+    } else {
+      console.log('robots.txt file updated with merged content');
+    }
+  });
 });

--- a/generateRobotsTxt.js
+++ b/generateRobotsTxt.js
@@ -1,0 +1,26 @@
+// Import the file system module
+const fileSystem = require('fs');
+
+// Import the merged agents file
+const agents = require('./agents.json');
+
+// Generate the rules for allowed agents
+let rules = [];
+
+agents.allowed.forEach(userAgent => {
+  rules.push(`User-agent: ${userAgent}\nAllow: /`);
+});
+
+// Generate the rules for disallowed agents
+agents.disallowed.forEach(userAgent => {
+  rules.push(`User-agent: ${userAgent}\nDisallow: /`);
+});
+
+// Write the combined rules to a robots.txt file
+fileSystem.writeFile('./robots.txt', rules.join("\n\n"), err => {
+  if (err) {
+    console.error(err);
+  } else {
+    console.log("robots.txt file generated");
+  }
+});

--- a/netlify/edge-functions/bots.ts
+++ b/netlify/edge-functions/bots.ts
@@ -1,5 +1,5 @@
 import { Config } from "@netlify/edge-functions";
-import agents from "../../agents.json";
+import agents from "../../agents.json" assert { type: "json" };
 
 /* eslint-disable import/no-anonymous-default-export */
 

--- a/netlify/edge-functions/bots.ts
+++ b/netlify/edge-functions/bots.ts
@@ -1,0 +1,31 @@
+import { Config } from "@netlify/edge-functions";
+import agents from "../../agents.json";
+
+/* eslint-disable import/no-anonymous-default-export */
+
+export default async (request: Request) => {
+  const userAgent = request.headers.get('user-agent')?.toLowerCase() || '';
+  
+  // Check if the User-Agent is in the allowed list
+  const isAllowed = agents.allowed.some(agent => userAgent.includes(agent.toLowerCase()));
+
+  // Check if the User-Agent is in the disallowed list
+  const isDisallowed = agents.disallowed.some(agent => userAgent.includes(agent.toLowerCase()));
+
+  // If the User-Agent is explicitly disallowed, block it
+  if (isDisallowed) {
+    return new Response(null, { status: 401 });
+  }
+
+  // If the User-Agent is allowed, or if it does not match any disallowed agent, allow access
+  if (isAllowed || !isDisallowed) {
+    return; // Allow access
+  }
+
+  // Block any User-Agent not in the allowed list
+  return new Response(null, { status: 401 });
+};
+
+export const config: Config = {
+  path: "*" as `/${string}`,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "kedro-website",
       "dependencies": {
         "@contentful/rich-text-react-renderer": "^15.12.1",
+        "@netlify/edge-functions": "^2.11.0",
         "classnames": "^2.3.2",
         "framer-motion": "^6.2.7",
         "next": "^14.2.12",
@@ -2034,6 +2035,11 @@
         "hey-listen": "^1.0.8",
         "tslib": "^2.3.1"
       }
+    },
+    "node_modules/@netlify/edge-functions": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.11.0.tgz",
+      "integrity": "sha512-DZrDHdPX44Cj7T9geKdiIwHB6OScL7QFL10voC8TApgEwY/NhKfABBGF2cbUIfbAh3IAMBeikelT8PU0MqYnyg=="
     },
     "node_modules/@next/env": {
       "version": "14.2.12",
@@ -13966,6 +13972,11 @@
         "hey-listen": "^1.0.8",
         "tslib": "^2.3.1"
       }
+    },
+    "@netlify/edge-functions": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.11.0.tgz",
+      "integrity": "sha512-DZrDHdPX44Cj7T9geKdiIwHB6OScL7QFL10voC8TApgEwY/NhKfABBGF2cbUIfbAh3IAMBeikelT8PU0MqYnyg=="
     },
     "@next/env": {
       "version": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kedro-website",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "node ./generateRobotsTxt.js && next build",
     "dev": "next dev",
     "format": "prettier --write .",
     "lint": "next lint",
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@contentful/rich-text-react-renderer": "^15.12.1",
+    "@netlify/edge-functions": "^2.11.0",
     "classnames": "^2.3.2",
     "framer-motion": "^6.2.7",
     "next": "^14.2.12",


### PR DESCRIPTION
## Description

Resolves https://github.com/kedro-org/kedro-website/issues/198

This pull request introduces several changes to manage web crawlers more effectively by updating the `robots.txt` file and handling user-agent requests. The most important changes include the addition of allowed and disallowed agents, generating `robots.txt` dynamically, and implementing edge functions to handle user-agent requests.

## Development notes

* [`agents.json`](diffhunk://#diff-15e11c2fca509b2f191942245c97d89c01d3b21735e8c6b7a85ab5044b3f8bcdR1-R37): Added lists of allowed and disallowed user agents for web crawlers.
* [`generateRobotsTxt.js`](diffhunk://#diff-f2412c2942de4a6865f1afc3a136824a3d15e4d09a826750b50f205edc1998c5R1-R26): Created a script to dynamically generate `robots.txt` based on the agents listed in `agents.json` when `npm run build` is executed. 
* [`netlify/edge-functions/bots.ts`](diffhunk://#diff-9a0474688c2a5261149394ff63789f7b34816ae0230cbec4d75922ea7a1fb8e5R1-R31): Implemented an edge function to handle requests based on user-agent headers, blocking disallowed agents and allowing others.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5): Updated the build script to include the generation of `robots.txt` before building the project.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17): Added `@netlify/edge-functions` as a dependency to support the new edge function.

**Note:**
As of now I am not fully sure which to allow and disallowed but I created below list from [ai.robots.txt](https://github.com/ai-robots-txt/ai.robots.txt) and [darkvisitors.com](https://darkvisitors.com)

```
{
    "allowed": [
      "Googlebot",
      "Bingbot",
      "Applebot",
      "ChatGPT",
      "ChatGPT-User"
    ],
    "disallowed": [
      "Claude-Web",
      "ClaudeBot",
      "AI2Bot",
      "anthropic-ai",
      "AwarioRssBot",
      "AwarioSmartBot",
      "Bytespider",
      "CCBot",
      "diffbot",
      "PerplexityBot",
      "Omgili",
      "ImagesiftBot",
      "Youbot",
      "Applebot-Extended",
      "Facebookbot",
      "FacebookBot",
      "Meta-ExternalAgent",
      "Meta-ExternalFetcher",
      "Kangaroo Bot",
      "Timpibot",
      "Webzio-Extended",
      "DuckAssistBot",
      "OAI-SearchBot",
      "Amazonbot",
      "Google-Extended"
    ]
  }
```