### PR TITLE
Update expired Slack invite links

### DIFF
--- a/modules/index/faq/faq-content.ts
+++ b/modules/index/faq/faq-content.ts
@@ -31,6 +31,6 @@ export const faqContent = [
   },
   {
     question: 'How can I find out more about Kedro?',
-    answer: `You can find the [Kedro community on Slack](https://slack.kedro.org/). Discussions from the [Slack channels are also archived online](https://linen-slack.kedro.org/), as are those from an [earlier set of Discord channels](https://linen-discord.kedro.org/).`,
+    answer: `You can find the [Kedro community on Slack](https://kedro-org.slack.com/join/shared_invite/zt-3mloycxx0-8uXHeLkYOJgWSf5865WKTw#/shared-invite/email). Discussions from the [Slack channels are also archived online](https://linen-slack.kedro.org/), as are those from an [earlier set of Discord channels](https://linen-discord.kedro.org/).`,
   },
 ];

--- a/modules/index/faq/faq.tsx
+++ b/modules/index/faq/faq.tsx
@@ -43,7 +43,7 @@ export default function FAQ() {
           <h3>FAQs</h3>
           <p>
             You can find the{' '}
-            <a href="https://slack.kedro.org/" target="_blank" rel="noreferrer">
+            <a href="https://kedro-org.slack.com/join/shared_invite/zt-3mloycxx0-8uXHeLkYOJgWSf5865WKTw#/shared-invite/email" target="_blank" rel="noreferrer">
               Kedro community on Slack
             </a>
             .

--- a/modules/index/footer/footer.tsx
+++ b/modules/index/footer/footer.tsx
@@ -46,7 +46,7 @@ export default function Footer() {
           <div className={style.iconLinks}>
             <a
               className={style.link}
-              href="https://slack.kedro.org"
+              href="https://kedro-org.slack.com/join/shared_invite/zt-3mloycxx0-8uXHeLkYOJgWSf5865WKTw#/shared-invite/email"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/modules/shared/header/header.tsx
+++ b/modules/shared/header/header.tsx
@@ -52,7 +52,7 @@ export default function Header() {
           <div className={style.iconLinks}>
             <a
               className={style.link}
-              href="https://slack.kedro.org"
+              href="https://kedro-org.slack.com/join/shared_invite/zt-3mloycxx0-8uXHeLkYOJgWSf5865WKTw#/shared-invite/email"
               rel="noopener noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
## Description

This PR updates the Kedro Slack invite link across the website to replace expired URLs with a valid, up-to-date Slack invite, ensuring users can successfully join the Kedro community.

## Development notes
- Replaced expired Kedro Slack invite links with the updated invite URL:
https://kedro-org.slack.com/join/shared_invite/zt-3mloycxx0-8uXHeLkYOJgWSf5865WKTw#/shared-invite/email

## QA notes
- Verified locally by running npm run dev.
- Confirmed that clicking the Slack link opens a valid Slack invite page.
