### PR TITLE
Remove heap analytics 

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,10 +6,6 @@ import '../styles/global.scss';
 function KedroWebsite({ Component, pageProps }: AppProps) {
   return (
     <>
-      <Script id="heap">
-        {`window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};   
-          heap.load(${process.env.NEXT_PUBLIC_ANALYTICS_ID}); `}
-      </Script>
       <Component {...pageProps} />
     </>
   );


### PR DESCRIPTION
This pull request removes the Heap Analytics tracking script from the main application component. This means user analytics will no longer be collected via Heap.

- Analytics removal:
  * Deleted the Heap Analytics initialization script from `pages/_app.tsx`, stopping the collection of analytics data using Heap.## Description