### PR TITLE
Handle base vendor url for local

### DIFF
--- a/public/consent/kedro-consent.js
+++ b/public/consent/kedro-consent.js
@@ -45,19 +45,21 @@
   };
 
   /**
-   * Get the base URL for vendor assets.
-   * - On localhost: use relative path (local files)
-   * - On production: use absolute kedro.org URL
+   * Derive the vendor folder URL from the consent script's own src.
+   * Vendor files live next to kedro-consent.js, so wherever the script
+   * was loaded from is where its vendor folder is.
    */
   function getVendorBaseUrl() {
-    const hostname = window.location.hostname;
-    
-    // Localhost - use relative path for local development
-    if (hostname === 'localhost' || hostname === '127.0.0.1') {
-      return '/consent/vendor';
+    try {
+      const scriptEl = document.querySelector('script[src*="kedro-consent"]');
+      if (scriptEl && scriptEl.src) {
+        const url = new URL(scriptEl.src);
+        const vendorPath = url.pathname.replace(/\/[^/]+$/, '/vendor');
+        return `${url.origin}${vendorPath}`;
+      }
+    } catch (e) {
+      // Fall through to fallback
     }
-    
-    // Production - always load from kedro.org (single source of truth)
     return 'https://kedro.org/consent/vendor';
   }
 


### PR DESCRIPTION
This pull request updates how the `kedro-consent.js` script determines the URL for loading vendor assets. Instead of relying on the hostname to decide between local and production paths, the script now dynamically derives the vendor folder location based on where the consent script itself was loaded from. This improves flexibility and reliability, especially in environments other than localhost or kedro.org.

**Asset loading logic update:**

* [`public/consent/kedro-consent.js`](diffhunk://#diff-ebaa3ecb4aa1a36684f86ef7b66d7db47c56255c39618e8d40be00e4facb5976L48-L60): Changed the `getVendorBaseUrl` function to derive the vendor folder URL from the script's own `src` attribute, ensuring vendor assets are loaded relative to the script's actual location, with a fallback to the kedro.org CDN if detection fails.