### PR TITLE
Detect and apply CMP theme based on host

### DIFF
--- a/public/consent/kedro-consent.js
+++ b/public/consent/kedro-consent.js
@@ -758,7 +758,7 @@
       '}',
       '',
       '#cc-main .cm__btn, #cc-main .pm__btn {',
-      '  border-radius: 4px;',
+      '  border-radius: 0;',
       '  font-weight: 600;',
       '  white-space: nowrap;',
       '}',

--- a/public/consent/kedro-consent.js
+++ b/public/consent/kedro-consent.js
@@ -165,17 +165,196 @@
     return host === 'www.kedro.org' ? 'kedro.org' : host;
   }
 
+  // ============================================
+  // THEME DETECTION
+  // ============================================
+
+  function isValidTheme(value) {
+    return value === 'light' || value === 'dark';
+  }
+
   /**
-   * Resolve which theme variant the consent banner should render.
-   * Per-host detection (kedro.org / docs / viz / builder) is intentionally
-   * deferred — for now, returns 'dark' (matches kedro.org default) unless
-   * the host explicitly sets `window.kedroConsentTheme`.
+   * Read the kedro-viz / kedro-builder theme convention (`kui-theme--*` class).
    */
-  function getTheme() {
-    if (window.kedroConsentTheme === 'light' || window.kedroConsentTheme === 'dark') {
-      return window.kedroConsentTheme;
+  function readKuiThemeClass(el) {
+    if (!el) {return null;}
+    if (el.classList.contains('kui-theme--dark')) {return 'dark';}
+    if (el.classList.contains('kui-theme--light')) {return 'light';}
+    return null;
+  }
+
+  /**
+   * Probe known host DOM theme signals — host-agnostic by design, so this
+   * also works on localhost / preview URLs running any of the kedro apps.
+   * Returns 'light' | 'dark' | null.
+   */
+  function readDomSignal() {
+    // Builder: kui-theme--* on <html>
+    const htmlClass = readKuiThemeClass(document.documentElement);
+    if (htmlClass) {return htmlClass;}
+
+    // Viz: kui-theme--* on .kedro-pipeline (React-mounted)
+    const pipelineClass = readKuiThemeClass(document.querySelector('.kedro-pipeline'));
+    if (pipelineClass) {return pipelineClass;}
+
+    // Docs (MkDocs Material): data-md-color-scheme on <body>
+    if (document.body) {
+      const scheme = document.body.getAttribute('data-md-color-scheme');
+      if (isValidTheme(scheme)) {return scheme;}
     }
-    return 'dark';
+
+    return null;
+  }
+
+  /**
+   * Read the user's saved theme from each host's localStorage. Used as a
+   * pre-mount fallback for viz and builder so the banner doesn't flash the
+   * wrong theme before React applies its DOM signal.
+   */
+  function readLocalStorageSignal() {
+    try {
+      const builderTheme = localStorage.getItem('kedro_builder_theme');
+      if (isValidTheme(builderTheme)) {return builderTheme;}
+    } catch (e) {
+      // localStorage access can throw (Safari private mode); fall through
+    }
+
+    try {
+      const vizRaw = localStorage.getItem('KedroViz');
+      if (vizRaw) {
+        const vizState = JSON.parse(vizRaw);
+        if (vizState && isValidTheme(vizState.theme)) {return vizState.theme;}
+      }
+    } catch (e) {
+      // Malformed JSON or storage error; fall through
+    }
+
+    return null;
+  }
+
+  /**
+   * Per-host fallback used only when no DOM/localStorage signal is present.
+   * Returns null for localhost / unknown hosts (caller defaults to 'dark').
+   */
+  function getHostFallback() {
+    const hostname = normalizeHostname();
+    const pathname = window.location.pathname;
+
+    if (hostname === 'demo.kedro.org' && pathname.startsWith('/kedro-builder')) {
+      return 'light';
+    }
+    if (hostname === 'demo.kedro.org') {return 'dark';}
+    if (hostname === 'docs.kedro.org') {return 'light';}
+    if (hostname === 'kedro.org')      {return 'dark';}
+
+    return null;
+  }
+
+  /**
+   * Resolve the current theme.
+   *
+   *   1. Explicit override     (window.kedroConsentTheme)
+   *   2. Live DOM signal       (works on any host, including localhost)
+   *   3. Persisted localStorage (covers viz/builder pre-mount window)
+   *   4. Host fallback          (per-host default when nothing above hits)
+   *   5. 'dark'                 (final default)
+   */
+  function resolveTheme() {
+    if (isValidTheme(window.kedroConsentTheme)) {return window.kedroConsentTheme;}
+
+    const dom = readDomSignal();
+    if (dom) {return dom;}
+
+    const stored = readLocalStorageSignal();
+    if (stored) {return stored;}
+
+    return getHostFallback() || 'dark';
+  }
+
+  /**
+   * Write the theme to <html data-kedro-cc-theme>. No-op when unchanged.
+   */
+  function applyTheme(theme) {
+    if (!isValidTheme(theme)) {return;}
+    const root = document.documentElement;
+    if (root.getAttribute('data-kedro-cc-theme') === theme) {return;}
+    root.setAttribute('data-kedro-cc-theme', theme);
+    log('Theme applied: ' + theme);
+  }
+
+  /**
+   * Single resolve + apply pipeline. Called at bootstrap and from every
+   * observer below — observers carry no resolution logic of their own.
+   */
+  function syncConsentTheme() {
+    applyTheme(resolveTheme());
+  }
+
+  function observeAttribute(target, attr, callback) {
+    if (!target) {return null;}
+    const observer = new MutationObserver(callback);
+    observer.observe(target, { attributes: true, attributeFilter: [attr] });
+    return observer;
+  }
+
+  /**
+   * Observe `attr` on `selector`. If the element doesn't exist yet (e.g. a
+   * React-mounted div), watch the DOM tree until it appears, then transfer
+   * observation. Re-fires the callback once the target shows up so the
+   * pre-mount theme can be re-resolved against the now-present signal.
+   */
+  function observeWhenAvailable(selector, attr, callback) {
+    const existing = document.querySelector(selector);
+    if (existing) {
+      return observeAttribute(existing, attr, callback);
+    }
+    const treeObserver = new MutationObserver(() => {
+      const found = document.querySelector(selector);
+      if (found) {
+        treeObserver.disconnect();
+        observeAttribute(found, attr, callback);
+        callback();
+      }
+    });
+    treeObserver.observe(document.body || document.documentElement, {
+      childList: true,
+      subtree: true
+    });
+    return treeObserver;
+  }
+
+  /**
+   * Subscribe to mutations on every known theme-signal location. Each
+   * watcher just calls syncConsentTheme — no resolution logic lives here.
+   */
+  function watchHostTheme() {
+    if (isValidTheme(window.kedroConsentTheme)) {
+      return;
+    }
+
+    // <html> kui-theme--* class (builder). Element always exists — cheap.
+    observeAttribute(document.documentElement, 'class', syncConsentTheme);
+
+    // <body> data-md-color-scheme (MkDocs Material on docs). Cheap.
+    if (document.body) {
+      observeAttribute(document.body, 'data-md-color-scheme', syncConsentTheme);
+    }
+
+    // .kedro-pipeline (viz wrapper) is React-mounted, so it may not exist yet.
+    //   - If already mounted → cheap targeted observer.
+    //   - Otherwise → only install the subtree-wait observer where viz might
+    //     actually render (viz host, or localhost for local viz dev). This
+    //     avoids a forever subtree MutationObserver on hosts that will never
+    //     see .kedro-pipeline (kedro.org, docs, builder, etc.).
+    const pipeline = document.querySelector('.kedro-pipeline');
+    if (pipeline) {
+      observeAttribute(pipeline, 'class', syncConsentTheme);
+    } else if (
+      (normalizeHostname() === 'demo.kedro.org' && !window.location.pathname.startsWith('/kedro-builder'))
+      || isLocalhost()
+    ) {
+      observeWhenAvailable('.kedro-pipeline', 'class', syncConsentTheme);
+    }
   }
 
   // ============================================
@@ -819,10 +998,11 @@
   function bootstrap() {
     const vendorUrl = getVendorBaseUrl();
 
-    // Apply theme attribute to <html> before loading vendor CSS, so the
-    // CSS variables resolve to the right palette the moment cookieconsent.css
-    // mounts. Per-host detection is TODO.
-    document.documentElement.setAttribute('data-kedro-cc-theme', getTheme());
+    // Resolve and apply the host's current theme to <html> before vendor CSS
+    // loads, so the consent CSS variables hit the correct palette on first
+    // paint. watchHostTheme() then keeps the banner in sync with live toggles.
+    syncConsentTheme();
+    watchHostTheme();
 
     loadAsset('css', `${vendorUrl}/cookieconsent.css`)
       .then(() => {

--- a/public/consent/kedro-consent.js
+++ b/public/consent/kedro-consent.js
@@ -86,16 +86,43 @@
     { host: 'kedro.org', ids: HEAP_IDS.KEDRO_ORG }
   ];
 
-  const COLORS = {
+  // Theme palettes — colours from Figma "Privacy-Banner_Light-Mode" / "Dark-Mode"
+  const LIGHT_COLORS = {
+    bg: '#ffffff',
+    title: '#242424',
+    body: '#747474',
     accent: '#ffc900',
     accentHover: '#e6b500',
-    bgGrey: '#1e1e1f',
-    bgGreyLight: '#151515',
-    bgGreyHover: '#2a2a2a',
-    fontDark: '#0b0b0b',
-    fontGrey: '#8e8e8e',
-    fontWhite: '#ffffff',
-    greyBorder: '#434343'
+    accentText: '#000000',
+    outlinedBorder: '#242424',
+    outlinedText: '#242424',
+    outlinedHoverBg: 'rgba(36, 36, 36, 0.05)',
+    blockBg: '#f5f5f5',
+    blockHover: '#ebebeb',
+    border: '#e0e0e0',
+    overlay: 'rgba(0, 0, 0, 0.45)',
+    closeBg: '#f5f5f5',
+    closeText: '#000',
+    closeHoverBg: '#ebebeb'
+  };
+
+  const DARK_COLORS = {
+    bg: '#1e1e1f',
+    title: '#d9dcde',
+    body: '#b2b2b2',
+    accent: '#ffc900',
+    accentHover: '#e6b500',
+    accentText: '#000000',
+    outlinedBorder: '#ffffff',
+    outlinedText: '#ffffff',
+    outlinedHoverBg: 'rgba(255, 255, 255, 0.1)',
+    blockBg: '#151515',
+    blockHover: '#2a2a2a',
+    border: '#434343',
+    overlay: 'rgba(0, 0, 0, 0.65)',
+    closeBg: '#151515',
+    closeText: '#ffffff',
+    closeHoverBg: '#2a2a2a'
   };
 
   // ============================================
@@ -136,6 +163,19 @@
   function normalizeHostname(hostname) {
     const host = hostname || window.location.hostname;
     return host === 'www.kedro.org' ? 'kedro.org' : host;
+  }
+
+  /**
+   * Resolve which theme variant the consent banner should render.
+   * Per-host detection (kedro.org / docs / viz / builder) is intentionally
+   * deferred — for now, returns 'dark' (matches kedro.org default) unless
+   * the host explicitly sets `window.kedroConsentTheme`.
+   */
+  function getTheme() {
+    if (window.kedroConsentTheme === 'light' || window.kedroConsentTheme === 'dark') {
+      return window.kedroConsentTheme;
+    }
+    return 'dark';
   }
 
   // ============================================
@@ -467,26 +507,71 @@
   // ============================================
 
   function injectCustomStyles() {
+    // CookieConsent variables — same shape for both palettes.
+    // Note: --cc-btn-secondary-* is intentionally set to the accent so that
+    // "Only necessary" matches "Accept analytics" (per Figma — equal weight
+    // consent choices). "Cookie settings" is overridden separately to outlined.
+    const themeVars = (palette) => [
+      `  --cc-bg: ${palette.bg};`,
+      `  --cc-primary-color: ${palette.title};`,
+      `  --cc-secondary-color: ${palette.body};`,
+      `  --cc-btn-primary-bg: ${palette.accent};`,
+      `  --cc-btn-primary-color: ${palette.accentText};`,
+      `  --cc-btn-primary-hover-bg: ${palette.accentHover};`,
+      `  --cc-btn-primary-hover-color: ${palette.accentText};`,
+      `  --cc-btn-secondary-bg: ${palette.accent};`,
+      `  --cc-btn-secondary-color: ${palette.accentText};`,
+      `  --cc-btn-secondary-hover-bg: ${palette.accentHover};`,
+      `  --cc-btn-secondary-hover-color: ${palette.accentText};`,
+      `  --cc-separator-border-color: ${palette.border};`,
+      `  --cc-cookie-category-block-bg: ${palette.blockBg};`,
+      `  --cc-cookie-category-block-hover-bg: ${palette.blockHover};`,
+      `  --cc-toggle-readonly-bg: ${palette.accent};`,
+      `  --cc-toggle-on-bg: ${palette.accent};`,
+      `  --cc-overlay-bg: ${palette.overlay};`
+    ];
+
+    // Outlined buttons — transparent bg + themed border + themed text:
+    //  - Banner "Cookie settings"           → .cm__btn[data-role="show"]
+    //  - Preferences popup "Save settings"  → .pm__btn[data-role="save"]
+    const outlinedRules = (selector, palette) => [
+      `${selector} #cc-main .cm__btn[data-role="show"],`,
+      `${selector} #cc-main .pm__btn[data-role="save"] {`,
+      '  background: transparent;',
+      `  border: 1px solid ${palette.outlinedBorder};`,
+      `  color: ${palette.outlinedText};`,
+      '}',
+      `${selector} #cc-main .cm__btn[data-role="show"]:hover,`,
+      `${selector} #cc-main .pm__btn[data-role="save"]:hover {`,
+      `  background: ${palette.outlinedHoverBg};`,
+      `  color: ${palette.outlinedText};`,
+      '}'
+    ];
+
+    // Close (X) button in the preferences popup — filled, no border.
+    // Light theme: dark grey fill + dark X. Dark theme: lighter grey fill + white X.
+    const closeButtonRules = (selector, palette) => [
+      `${selector} #cc-main .pm__close-btn {`,
+      `  background: ${palette.closeBg};`,
+      '  border: none;',
+      '}',
+      `${selector} #cc-main .pm__close-btn svg {`,
+      `  stroke: ${palette.closeText};`,
+      '}',
+      `${selector} #cc-main .pm__close-btn:hover {`,
+      `  background: ${palette.closeHoverBg};`,
+      `  color: ${palette.closeText};`,
+      '}'
+    ];
+
     const styles = [
       '/* Kedro Consent Branding */',
-      ':root {',
-      `  --cc-bg: ${COLORS.bgGrey};`,
-      `  --cc-primary-color: ${COLORS.fontWhite};`,
-      `  --cc-secondary-color: ${COLORS.fontGrey};`,
-      `  --cc-btn-primary-bg: ${COLORS.accent};`,
-      `  --cc-btn-primary-color: ${COLORS.fontDark};`,
-      `  --cc-btn-primary-hover-bg: ${COLORS.accentHover};`,
-      `  --cc-btn-primary-hover-color: ${COLORS.fontDark};`,
-      `  --cc-btn-secondary-bg: ${COLORS.bgGreyLight};`,
-      `  --cc-btn-secondary-color: ${COLORS.fontWhite};`,
-      `  --cc-btn-secondary-hover-bg: ${COLORS.bgGreyHover};`,
-      `  --cc-btn-secondary-hover-color: ${COLORS.fontWhite};`,
-      `  --cc-separator-border-color: ${COLORS.greyBorder};`,
-      `  --cc-cookie-category-block-bg: ${COLORS.bgGreyLight};`,
-      `  --cc-cookie-category-block-hover-bg: ${COLORS.bgGreyHover};`,
-      `  --cc-toggle-readonly-bg: ${COLORS.accent};`,
-      `  --cc-toggle-on-bg: ${COLORS.accent};`,
-      '  --cc-overlay-bg: rgba(0, 0, 0, 0.65);',
+      '[data-kedro-cc-theme="light"] {',
+      ...themeVars(LIGHT_COLORS),
+      '}',
+      '',
+      '[data-kedro-cc-theme="dark"] {',
+      ...themeVars(DARK_COLORS),
       '}',
       '',
       '#cc-main {',
@@ -495,13 +580,21 @@
       '',
       '#cc-main .cm__btn, #cc-main .pm__btn {',
       '  border-radius: 4px;',
-      '  font-weight: 500;',
+      '  font-weight: 600;',
       '  white-space: nowrap;',
       '}',
       '',
-      '.cm__title, .pm__title {',
+      '#cc-main .cm__title, #cc-main .pm__title {',
       '  font-weight: 600;',
-      '}'
+      '}',
+      '',
+      ...outlinedRules('[data-kedro-cc-theme="light"]', LIGHT_COLORS),
+      '',
+      ...outlinedRules('[data-kedro-cc-theme="dark"]', DARK_COLORS),
+      '',
+      ...closeButtonRules('[data-kedro-cc-theme="light"]', LIGHT_COLORS),
+      '',
+      ...closeButtonRules('[data-kedro-cc-theme="dark"]', DARK_COLORS)
     ];
 
     const styleEl = document.createElement('style');
@@ -601,8 +694,6 @@
       },
       preferencesModal: {
         title: 'Cookie settings',
-        acceptAllBtn: 'Accept analytics',
-        acceptNecessaryBtn: 'Only necessary',
         savePreferencesBtn: 'Save settings',
         closeIconLabel: 'Close',
         sections: [
@@ -727,6 +818,11 @@
 
   function bootstrap() {
     const vendorUrl = getVendorBaseUrl();
+
+    // Apply theme attribute to <html> before loading vendor CSS, so the
+    // CSS variables resolve to the right palette the moment cookieconsent.css
+    // mounts. Per-host detection is TODO.
+    document.documentElement.setAttribute('data-kedro-cc-theme', getTheme());
 
     loadAsset('css', `${vendorUrl}/cookieconsent.css`)
       .then(() => {


### PR DESCRIPTION
This pull request introduces a comprehensive theme detection and dynamic theming system for the Kedro Consent banner, enabling seamless light and dark mode support across various Kedro host applications. The changes ensure the consent banner always matches the host app's theme, including on first paint and during live theme toggles. The update also refactors the CSS variable injection logic to support both palettes, and enhances the appearance of buttons and controls to match Figma designs.

The most important changes are:

**Dynamic Theme Detection and Application:**
- Added a robust theme resolution pipeline (`resolveTheme`, `syncConsentTheme`, etc.) that detects the current theme using DOM signals, localStorage, host-based fallbacks, and an explicit override, then applies it via a `data-kedro-cc-theme` attribute on `<html>`. Includes observers to keep the banner in sync with live theme changes. [[1]](diffhunk://#diff-ebaa3ecb4aa1a36684f86ef7b66d7db47c56255c39618e8d40be00e4facb5976R168-R359) [[2]](diffhunk://#diff-ebaa3ecb4aa1a36684f86ef7b66d7db47c56255c39618e8d40be00e4facb5976R1001-R1006)

**Palette Refactor and CSS Variable Injection:**
- Replaced the old `COLORS` object with `LIGHT_COLORS` and `DARK_COLORS` palettes, and refactored the CSS variable injection to generate theme-specific variables and rules for both light and dark modes. This includes new variables for backgrounds, borders, overlays, and button states, all matching Figma specifications. [[1]](diffhunk://#diff-ebaa3ecb4aa1a36684f86ef7b66d7db47c56255c39618e8d40be00e4facb5976L89-R125) [[2]](diffhunk://#diff-ebaa3ecb4aa1a36684f86ef7b66d7db47c56255c39618e8d40be00e4facb5976R689-R776)

**Button and Control Styling Improvements:**
- Updated button shapes (now square corners and heavier font weight), improved outlined button and close button styles for both themes, and ensured "Only necessary" and "Accept analytics" have equal visual weight per design guidance.

**Banner Bootstrap Enhancement:**
- Ensured the theme is resolved and applied before vendor CSS loads, preventing a flash of incorrect theme on first paint.

**Minor Cleanup:**
- Removed unused button labels from the preferences modal configuration for consistency.

## Light theme:
<img width="1800" height="211" alt="Screenshot 2026-05-08 at 5 23 45 p m" src="https://github.com/user-attachments/assets/55d24386-c342-4a03-bd3f-929c28d4a68d" />
<img width="793" height="696" alt="Screenshot 2026-05-08 at 5 24 02 p m" src="https://github.com/user-attachments/assets/618def85-6b0a-4850-9826-33fb9cc6db1e" />

## Dark theme:
<img width="1800" height="179" alt="Screenshot 2026-05-08 at 5 24 17 p m" src="https://github.com/user-attachments/assets/2cc38ebe-914e-4bd5-bb85-3b9b5c7bc324" />
<img width="810" height="700" alt="Screenshot 2026-05-08 at 5 24 37 p m" src="https://github.com/user-attachments/assets/0b8b77cd-ed0d-4840-9824-c353cd5ef8c5" />
