### PR TITLE
Potential fix for code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -201,46 +201,45 @@ export async function getAllPostsWithSlug() {
 
 export async function getAllPostsForBlog(preview) {
   const entries = await fetchGraphQL(
-    `query {
-      postCollection(order: sys_firstPublishedAt_DESC, preview: ${
-        preview ? 'true' : 'false'
-      }) {
+    `query GetAllPostsForBlog($preview: Boolean!) {
+      postCollection(order: sys_firstPublishedAt_DESC, preview: $preview) {
         items {
           ${BLOG_GRAPHQL_FIELDS}
         }
       }
     }`,
-    preview
+    preview,
+    { preview: !!preview }
   );
 
   return extractPostEntries(entries);
 }
 
 export async function getPostAndMorePosts(slug, preview) {
+  const variables = { slug, preview: !!preview };
+
   const entry = await fetchGraphQL(
-    `query {
-      postCollection(where: { slug: "${slug}" }, preview: ${
-      preview ? 'true' : 'false'
-    }, limit: 1) {
+    `query GetPostAndMorePosts($slug: String!, $preview: Boolean!) {
+      postCollection(where: { slug: $slug }, preview: $preview, limit: 1) {
         items {
           ${POST_GRAPHQL_FIELDS}
         }
       }
     }`,
-    preview
+    preview,
+    variables
   );
 
   const entries = await fetchGraphQL(
-    `query {
-      postCollection(where: { slug_not_in: "${slug}" }, order: sys_firstPublishedAt_DESC, preview: ${
-      preview ? 'true' : 'false'
-    }, limit: 5) {
+    `query GetMorePosts($slug: String!, $preview: Boolean!) {
+      postCollection(where: { slug_not_in: $slug }, order: sys_firstPublishedAt_DESC, preview: $preview, limit: 5) {
         items {
           ${POST_GRAPHQL_FIELDS}
         }
       }
     }`,
-    preview
+    preview,
+    variables
   );
 
   return {
@@ -269,8 +268,8 @@ export async function getAllAuthors() {
 
 export async function getSingleAuthor(author) {
   const entries = await fetchGraphQL(
-    `query {
-      authorCollection(where: {urlDisplayName: "${author}"}, limit: 20) {
+    `query GetSingleAuthor($author: String!) {
+      authorCollection(where: { urlDisplayName: $author }, limit: 20) {
         items {
           name
           bio
@@ -299,7 +298,9 @@ export async function getSingleAuthor(author) {
           }
         }
       }
-    }`
+    }`,
+    false,
+    { author }
   );
 
   return {

--- a/lib/api.js
+++ b/lib/api.js
@@ -333,11 +333,11 @@ export async function getUniquePostCategories() {
 
 export async function getCategoryPosts(category) {
   const entries = await fetchGraphQL(
-    `{
+    `query GetCategoryPosts($category: String!) {
       postCollection(
         limit: 10
         order: sys_firstPublishedAt_DESC
-        where: {category_contains: "${category}"}
+        where: { category_contains: $category }
       ) {
         items {
           sys {
@@ -358,7 +358,9 @@ export async function getCategoryPosts(category) {
           }
         }
       }
-    }`
+    }`,
+    false,
+    { category }
   );
 
   return {

--- a/lib/api.js
+++ b/lib/api.js
@@ -135,7 +135,7 @@ author {
 excerpt
 `;
 
-async function fetchGraphQL(query, preview = false) {
+async function fetchGraphQL(query, preview = false, variables = {}) {
   return fetch(
     `https://graphql.contentful.com/content/v1/spaces/${process.env.CONTENTFUL_SPACE_ID}`,
     {
@@ -148,7 +148,7 @@ async function fetchGraphQL(query, preview = false) {
             : process.env.CONTENTFUL_ACCESS_TOKEN
         }`,
       },
-      body: JSON.stringify({ query }),
+      body: JSON.stringify({ query, variables }),
     }
   ).then((response) => response.json());
 }
@@ -171,14 +171,15 @@ function extractPostEntries(fetchResponse) {
 
 export async function getPreviewPostBySlug(slug) {
   const entry = await fetchGraphQL(
-    `query {
-      postCollection(where: { slug: "${slug}" }, preview: true, limit: 1) {
+    `query GetPreviewPostBySlug($slug: String!) {
+      postCollection(where: { slug: $slug }, preview: true, limit: 1) {
         items {
           ${POST_GRAPHQL_FIELDS}
         }
       }
     }`,
-    true
+    true,
+    { slug }
   );
 
   return extractPost(entry);


### PR DESCRIPTION
Potential fix for [https://github.com/kedro-org/kedro-website/security/code-scanning/3](https://github.com/kedro-org/kedro-website/security/code-scanning/3)

Best fix: **stop interpolating user input into GraphQL query strings** and use **GraphQL variables** instead.

In `lib/api.js`, update `fetchGraphQL` so it can send both `query` and `variables` in the POST body. Then update all affected query-builder functions (those receiving `slug/category/author` etc.) to define query variables (e.g. `query($slug: String!)`) and reference them in `where` clauses (e.g. `slug: $slug`) rather than `"${slug}"`.

This preserves functionality while preventing query-structure injection. No behavior change is needed in the page files; calls can remain the same because variable binding happens inside `lib/api.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
